### PR TITLE
minor Note.hx optimization

### DIFF
--- a/source/funkin/game/Note.hx
+++ b/source/funkin/game/Note.hx
@@ -106,6 +106,7 @@ class Note extends FlxSprite
 		this.isSustainNote = sustain;
 		this.sustainLength = sustainLength;
 		this.strumLine = strumLine;
+		moves = false
 
 		x += 50;
 		// MAKE SURE ITS DEFINITELY OFF SCREEN?

--- a/source/funkin/game/Note.hx
+++ b/source/funkin/game/Note.hx
@@ -106,7 +106,7 @@ class Note extends FlxSprite
 		this.isSustainNote = sustain;
 		this.sustainLength = sustainLength;
 		this.strumLine = strumLine;
-		moves = false
+		moves = false;
 
 		x += 50;
 		// MAKE SURE ITS DEFINITELY OFF SCREEN?


### PR DESCRIPTION
`FlxSprite` has unnecessary calculations for velocity and other stuff if the variable `moves` isn't set to `false`, if the mod creator wants to make use of velocity again they can set it back to true, so what I simply did was `moves = false;`.