### PR TITLE
Strum Extensibility

### DIFF
--- a/source/funkin/backend/scripting/events/StrumCreationEvent.hx
+++ b/source/funkin/backend/scripting/events/StrumCreationEvent.hx
@@ -22,6 +22,11 @@ final class StrumCreationEvent extends CancellableEvent {
 	public var strumID:Int;
 
 	/**
+	 * Animation prefix (`left` = `arrowLEFT`, `left press`, `left confirm`).
+	 */
+	public var animPrefix:String;
+
+	/**
 	 * Sprite path, in case you only want to change the sprite.
 	 */
 	public var sprite:String = "game/notes/default";

--- a/source/funkin/game/Note.hx
+++ b/source/funkin/game/Note.hx
@@ -61,7 +61,7 @@ class Note extends FlxSprite
 
 	public var strumID(get, never):Int;
 	private function get_strumID() {
-		var id = noteData % 4;
+		var id = noteData % strumLine.members.length;
 		if (id < 0) id = 0;
 		return id;
 	}

--- a/source/funkin/game/PlayState.hx
+++ b/source/funkin/game/PlayState.hx
@@ -661,6 +661,8 @@ class PlayState extends MusicBeatState
 		healthBarBG.scrollFactor.set();
 		add(healthBarBG);
 
+		
+
 		healthBar = new FlxBar(healthBarBG.x + 4, healthBarBG.y + 4, RIGHT_TO_LEFT, Std.int(healthBarBG.width - 8), Std.int(healthBarBG.height - 8), this,
 			'health', 0, maxHealth);
 		healthBar.scrollFactor.set();

--- a/source/funkin/game/PlayState.hx
+++ b/source/funkin/game/PlayState.hx
@@ -635,6 +635,12 @@ class PlayState extends MusicBeatState
 
 		// CAMERA & HUD INITIALISATION
 		#if REGION
+
+		if (!scripts.event("onPreGenerateStrums", new CancellableEvent()).cancelled) {
+			generateStrums();
+			scripts.call("onPostGenerateStrums");
+		}
+
 		for(str in strumLines)
 			str.generate(str.data, (chartingMode && Charter.startHere) ? Charter.startTime : null);
 
@@ -661,7 +667,7 @@ class PlayState extends MusicBeatState
 		healthBarBG.scrollFactor.set();
 		add(healthBarBG);
 
-		
+
 
 		healthBar = new FlxBar(healthBarBG.x + 4, healthBarBG.y + 4, RIGHT_TO_LEFT, Std.int(healthBarBG.width - 8), Std.int(healthBarBG.height - 8), this,
 			'health', 0, maxHealth);
@@ -784,11 +790,6 @@ class PlayState extends MusicBeatState
 			inCutscene = false;
 
 			if (scripts.event("onStartCountdown", new CancellableEvent()).cancelled) return;
-		}
-
-		if (!scripts.event("onPreGenerateStrums", new CancellableEvent()).cancelled) {
-			generateStrums();
-			scripts.call("onPostGenerateStrums");
 		}
 
 		startedCountdown = true;

--- a/source/funkin/game/Strum.hx
+++ b/source/funkin/game/Strum.hx
@@ -12,6 +12,38 @@ class Strum extends FlxSprite {
 	
 	public var lastDrawCameras(default, null):Array<FlxCamera> = [];
 
+	public var getPressed:StrumLine->Bool = null;
+	public var getJustPressed:StrumLine->Bool = null;
+	public var getJustReleased:StrumLine->Bool = null;
+
+	public inline function __getPressed(strumLine:StrumLine):Bool {
+		return getPressed != null ? getPressed(strumLine) : switch(ID) {
+			case 0: strumLine.controls.NOTE_LEFT;
+			case 1: strumLine.controls.NOTE_DOWN;
+			case 2: strumLine.controls.NOTE_UP;
+			case 3: strumLine.controls.NOTE_RIGHT;
+			default: false;
+		}
+	}
+	public inline function __getJustPressed(strumLine:StrumLine) {
+		return getJustPressed != null ? getJustPressed(strumLine) : switch(ID) {
+			case 0: strumLine.controls.NOTE_LEFT_P;
+			case 1: strumLine.controls.NOTE_DOWN_P;
+			case 2: strumLine.controls.NOTE_UP_P;
+			case 3: strumLine.controls.NOTE_RIGHT_P;
+			default: false;
+		}
+	}
+	public inline function __getJustReleased(strumLine:StrumLine) {
+		return getJustReleased != null ? getJustReleased(strumLine) : switch(ID) {
+			case 0: strumLine.controls.NOTE_LEFT_R;
+			case 1: strumLine.controls.NOTE_DOWN_R;
+			case 2: strumLine.controls.NOTE_UP_R;
+			case 3: strumLine.controls.NOTE_RIGHT_R;
+			default: false;
+		}
+	}
+
 	public inline function getScrollSpeed(?note:Note):Float {
 		if (note != null && note.scrollSpeed != null) return note.scrollSpeed;
 		if (scrollSpeed != null) return scrollSpeed;

--- a/source/funkin/game/Strum.hx
+++ b/source/funkin/game/Strum.hx
@@ -9,7 +9,7 @@ class Strum extends FlxSprite {
 
 	public var scrollSpeed:Null<Float> = null; // custom scroll speed per strum
 	public var noteAngle:Null<Float> = null;
-	
+
 	public var lastDrawCameras(default, null):Array<FlxCamera> = [];
 
 	public var getPressed:StrumLine->Bool = null;
@@ -50,7 +50,7 @@ class Strum extends FlxSprite {
 		if (PlayState.instance != null) return PlayState.instance.scrollSpeed;
 		return 1;
 	}
-	
+
 	public inline function getNotesAngle(?note:Note):Float {
 		if (note != null && note.noteAngle != null) return note.noteAngle;
 		if (noteAngle != null) return noteAngle;
@@ -76,7 +76,7 @@ class Strum extends FlxSprite {
 
 	public function updateNotePosition(daNote:Note) {
 		if (!daNote.exists) return;
-	
+
 		daNote.__strumCameras = lastDrawCameras;
 		daNote.__strum = this;
 		daNote.scrollFactor.set(scrollFactor.x, scrollFactor.y);
@@ -95,7 +95,7 @@ class Strum extends FlxSprite {
 			var realOffset = FlxPoint.get(0, 0);
 
 			if (daNote.isSustainNote) offset.y -= N_WIDTHDIV2;
-			
+
 			if (Std.int(daNote.__noteAngle % 360) != 0) {
 				var noteAngleCos = FlxMath.fastCos(daNote.__noteAngle / PIX180);
 				var noteAngleSin = FlxMath.fastSin(daNote.__noteAngle / PIX180);
@@ -113,9 +113,9 @@ class Strum extends FlxSprite {
 				realOffset.y = offset.y;
 			}
 			realOffset.y *= -1;
-	
+
 			daNote.setPosition(x + realOffset.x, y + realOffset.y);
-			
+
 			offset.put();
 			realOffset.put();
 		}

--- a/source/funkin/game/StrumLine.hx
+++ b/source/funkin/game/StrumLine.hx
@@ -187,9 +187,11 @@ class StrumLine extends FlxTypedGroup<Strum> {
 		__justPressed.clear();
 		__justReleased.clear();
 
-		__pressed.pushGroup(controls.NOTE_LEFT, controls.NOTE_DOWN, controls.NOTE_UP, controls.NOTE_RIGHT);
-		__justPressed.pushGroup(controls.NOTE_LEFT_P, controls.NOTE_DOWN_P, controls.NOTE_UP_P, controls.NOTE_RIGHT_P);
-		__justReleased.pushGroup(controls.NOTE_LEFT_R, controls.NOTE_DOWN_R, controls.NOTE_UP_R, controls.NOTE_RIGHT_R);
+		for(s in members) {
+			__pressed.push(s.__getPressed(this));
+			__justPressed.push(s.__getJustPressed(this));
+			__justReleased.push(s.__getJustReleased(this));
+		}
 
 		var event = PlayState.instance.scripts.event("onKeyShit", EventManager.get(InputSystemEvent).recycle(__pressed, __justPressed, __justReleased, this, id));
 		if (event.cancelled) return;
@@ -232,60 +234,62 @@ class StrumLine extends FlxTypedGroup<Strum> {
 	public inline function addHealth(health:Float)
 		PlayState.instance.health += health * (opponentSide ? -1 : 1);
 
-	public function generateStrums(amount:Int = 4) {
+	public inline function generateStrums(amount:Int = 4) {
 		for (i in 0...4)
-		{
-			var babyArrow:Strum = new Strum((FlxG.width * strumOffset) + (Note.swagWidth * (i - 2)), PlayState.instance.strumLine.y);
-			babyArrow.ID = i;
+			add(createStrum(i));
+	}
 
-			var event = PlayState.instance.scripts.event("onStrumCreation", EventManager.get(StrumCreationEvent).recycle(babyArrow, PlayState.instance.strumLines.members.indexOf(this), i));
+	public function createStrum(i:Int, spr:Int = -1) {
+		var babyArrow:Strum = new Strum((FlxG.width * strumOffset) + (Note.swagWidth * (i - 2)), PlayState.instance.strumLine.y);
+		babyArrow.ID = i;
+		if (spr < 0)
+			spr = i % 4;
 
-			if (!event.cancelled) {
-				babyArrow.frames = Paths.getFrames(event.sprite);
-				babyArrow.animation.addByPrefix('green', 'arrowUP');
-				babyArrow.animation.addByPrefix('blue', 'arrowDOWN');
-				babyArrow.animation.addByPrefix('purple', 'arrowLEFT');
-				babyArrow.animation.addByPrefix('red', 'arrowRIGHT');
+		var event = PlayState.instance.scripts.event("onStrumCreation", EventManager.get(StrumCreationEvent).recycle(babyArrow, PlayState.instance.strumLines.members.indexOf(this), i));
 
-				babyArrow.antialiasing = true;
-				babyArrow.setGraphicSize(Std.int(babyArrow.width * 0.7));
+		if (!event.cancelled) {
+			babyArrow.frames = Paths.getFrames(event.sprite);
+			babyArrow.animation.addByPrefix('green', 'arrowUP');
+			babyArrow.animation.addByPrefix('blue', 'arrowDOWN');
+			babyArrow.animation.addByPrefix('purple', 'arrowLEFT');
+			babyArrow.animation.addByPrefix('red', 'arrowRIGHT');
 
-				switch (babyArrow.ID % 4)
-				{
-					case 0:
-						babyArrow.animation.addByPrefix('static', 'arrowLEFT');
-						babyArrow.animation.addByPrefix('pressed', 'left press', 24, false);
-						babyArrow.animation.addByPrefix('confirm', 'left confirm', 24, false);
-					case 1:
-						babyArrow.animation.addByPrefix('static', 'arrowDOWN');
-						babyArrow.animation.addByPrefix('pressed', 'down press', 24, false);
-						babyArrow.animation.addByPrefix('confirm', 'down confirm', 24, false);
-					case 2:
-						babyArrow.animation.addByPrefix('static', 'arrowUP');
-						babyArrow.animation.addByPrefix('pressed', 'up press', 24, false);
-						babyArrow.animation.addByPrefix('confirm', 'up confirm', 24, false);
-					case 3:
-						babyArrow.animation.addByPrefix('static', 'arrowRIGHT');
-						babyArrow.animation.addByPrefix('pressed', 'right press', 24, false);
-						babyArrow.animation.addByPrefix('confirm', 'right confirm', 24, false);
-				}
-			}
+			babyArrow.antialiasing = true;
+			babyArrow.setGraphicSize(Std.int(babyArrow.width * 0.7));
 
-			babyArrow.cpu = cpu;
-			babyArrow.updateHitbox();
-			babyArrow.scrollFactor.set();
-
-			if (event.__doAnimation)
+			switch (spr)
 			{
-				babyArrow.y -= 10;
-				babyArrow.alpha = 0;
-				FlxTween.tween(babyArrow, {y: babyArrow.y + 10, alpha: 1}, 1, {ease: FlxEase.circOut, startDelay: 0.5 + (0.2 * i)});
+				case 0:
+					babyArrow.animation.addByPrefix('static', 'arrowLEFT');
+					babyArrow.animation.addByPrefix('pressed', 'left press', 24, false);
+					babyArrow.animation.addByPrefix('confirm', 'left confirm', 24, false);
+				case 1:
+					babyArrow.animation.addByPrefix('static', 'arrowDOWN');
+					babyArrow.animation.addByPrefix('pressed', 'down press', 24, false);
+					babyArrow.animation.addByPrefix('confirm', 'down confirm', 24, false);
+				case 2:
+					babyArrow.animation.addByPrefix('static', 'arrowUP');
+					babyArrow.animation.addByPrefix('pressed', 'up press', 24, false);
+					babyArrow.animation.addByPrefix('confirm', 'up confirm', 24, false);
+				case 3:
+					babyArrow.animation.addByPrefix('static', 'arrowRIGHT');
+					babyArrow.animation.addByPrefix('pressed', 'right press', 24, false);
+					babyArrow.animation.addByPrefix('confirm', 'right confirm', 24, false);
 			}
-
-			add(babyArrow);
-
-			babyArrow.playAnim('static');
 		}
+
+		babyArrow.cpu = cpu;
+		babyArrow.updateHitbox();
+		babyArrow.scrollFactor.set();
+
+		if (event.__doAnimation)
+		{
+			babyArrow.y -= 10;
+			babyArrow.alpha = 0;
+			FlxTween.tween(babyArrow, {y: babyArrow.y + 10, alpha: 1}, 1, {ease: FlxEase.circOut, startDelay: 0.5 + (0.2 * i)});
+		}
+		babyArrow.playAnim('static');
+		return babyArrow;
 	}
 
 	/**

--- a/source/funkin/game/StrumLine.hx
+++ b/source/funkin/game/StrumLine.hx
@@ -193,7 +193,7 @@ class StrumLine extends FlxTypedGroup<Strum> {
 			__justReleased.push(s.__getJustReleased(this));
 		}
 
-		var event = PlayState.instance.scripts.event("onKeyShit", EventManager.get(InputSystemEvent).recycle(__pressed, __justPressed, __justReleased, this, id));
+		var event = PlayState.instance.scripts.event("onInputUpdate", EventManager.get(InputSystemEvent).recycle(__pressed, __justPressed, __justReleased, this, id));
 		if (event.cancelled) return;
 
 		__pressed = CoolUtil.getDefault(event.pressed, []);
@@ -226,9 +226,9 @@ class StrumLine extends FlxTypedGroup<Strum> {
 		for(e in __notePerStrum) if (e != null) PlayState.instance.goodNoteHit(this, e);
 
 		forEach(function(str:Strum) {
-			str.updatePlayerInput(__pressed[str.ID], __justPressed[str.ID], __justReleased[str.ID]);
+			str.updatePlayerInput(str.__getPressed(this), str.__getJustPressed(this), str.__getJustReleased(this));
 		});
-		PlayState.instance.scripts.call("onPostKeyShit");
+		PlayState.instance.scripts.call("onPostInputUpdate");
 	}
 
 	public inline function addHealth(health:Float)
@@ -239,13 +239,24 @@ class StrumLine extends FlxTypedGroup<Strum> {
 			add(createStrum(i));
 	}
 
-	public function createStrum(i:Int, spr:Int = -1) {
+	/**
+	 * Creates a strum and returns the created strum (needs to be added manually).
+	 * @param i Index of the strum
+	 * @param animPrefix (Optional) Animation prefix (`left` = `arrowLEFT`, `left press`, `left confirm`).
+	 */
+	public function createStrum(i:Int, ?animPrefix:String) {
+		if (animPrefix == null)
+			animPrefix = switch(i % 4) {
+				case 0: "left";
+				case 1: "down";
+				case 2: "up";
+				case 3: "right";
+				case _: "up";
+			}
 		var babyArrow:Strum = new Strum((FlxG.width * strumOffset) + (Note.swagWidth * (i - 2)), PlayState.instance.strumLine.y);
 		babyArrow.ID = i;
-		if (spr < 0)
-			spr = i % 4;
 
-		var event = PlayState.instance.scripts.event("onStrumCreation", EventManager.get(StrumCreationEvent).recycle(babyArrow, PlayState.instance.strumLines.members.indexOf(this), i));
+		var event = PlayState.instance.scripts.event("onStrumCreation", EventManager.get(StrumCreationEvent).recycle(babyArrow, PlayState.instance.strumLines.members.indexOf(this), i, animPrefix));
 
 		if (!event.cancelled) {
 			babyArrow.frames = Paths.getFrames(event.sprite);
@@ -257,25 +268,9 @@ class StrumLine extends FlxTypedGroup<Strum> {
 			babyArrow.antialiasing = true;
 			babyArrow.setGraphicSize(Std.int(babyArrow.width * 0.7));
 
-			switch (spr)
-			{
-				case 0:
-					babyArrow.animation.addByPrefix('static', 'arrowLEFT');
-					babyArrow.animation.addByPrefix('pressed', 'left press', 24, false);
-					babyArrow.animation.addByPrefix('confirm', 'left confirm', 24, false);
-				case 1:
-					babyArrow.animation.addByPrefix('static', 'arrowDOWN');
-					babyArrow.animation.addByPrefix('pressed', 'down press', 24, false);
-					babyArrow.animation.addByPrefix('confirm', 'down confirm', 24, false);
-				case 2:
-					babyArrow.animation.addByPrefix('static', 'arrowUP');
-					babyArrow.animation.addByPrefix('pressed', 'up press', 24, false);
-					babyArrow.animation.addByPrefix('confirm', 'up confirm', 24, false);
-				case 3:
-					babyArrow.animation.addByPrefix('static', 'arrowRIGHT');
-					babyArrow.animation.addByPrefix('pressed', 'right press', 24, false);
-					babyArrow.animation.addByPrefix('confirm', 'right confirm', 24, false);
-			}
+			babyArrow.animation.addByPrefix('static', 'arrow${event.animPrefix.toUpperCase()}');
+			babyArrow.animation.addByPrefix('pressed', '${event.animPrefix} press', 24, false);
+			babyArrow.animation.addByPrefix('confirm', '${event.animPrefix} confirm', 24, false);
 		}
 
 		babyArrow.cpu = cpu;
@@ -289,6 +284,8 @@ class StrumLine extends FlxTypedGroup<Strum> {
 			FlxTween.tween(babyArrow, {y: babyArrow.y + 10, alpha: 1}, 1, {ease: FlxEase.circOut, startDelay: 0.5 + (0.2 * i)});
 		}
 		babyArrow.playAnim('static');
+		
+		insert(i, babyArrow);
 		return babyArrow;
 	}
 


### PR DESCRIPTION
This PR allows you to add more than 4 strums to a strumline via scripting, while also changing its keybinds.

For example, this script below allows you to add a fifth strum (rotated up strum) controlled by the spacebar on the player's side, and each note has a 10% chance of being on that new strum.
![image](https://github.com/FNF-CNE-Devs/CodenameEngine/assets/134403819/a6b01643-c4dc-4f28-b39f-99692b8d1786)
```haxe
function onPostGenerateStrums() {
	for(i in 0...2)
		player.members[i].x -= Note.swagWidth * 0.5;
	for(i in 2...4)
		player.members[i].x += Note.swagWidth * 0.5;

	var str = player.createStrum(4, "up");
	str.x -= 2.5 * Note.swagWidth;
	str.noteAngle = 0;
	str.angle = 45;
	str.getPressed = function() {
		return FlxG.keys.pressed.SPACE;
	};
	str.getJustPressed = function() {
		return FlxG.keys.justPressed.SPACE;
	};
	str.getJustReleased = function() {
		return FlxG.keys.justReleased.SPACE;
	};
}

var lastChoice = false;

function onPostNoteCreation(event) {
	if (event.note.strumLine != player) return;

	if (event.note.isSustainNote) {
		if (lastChoice)
			event.note.noteData = 4;
	} else if (lastChoice = FlxG.random.bool(10)) {
		event.note.noteData = 4;
	}
}
```