### PR TITLE
Time left on Discord RPC bug fix

### DIFF
--- a/source/funkin/game/PlayState.hx
+++ b/source/funkin/game/PlayState.hx
@@ -1015,7 +1015,7 @@ class PlayState extends MusicBeatState
 	@:dox(hide)
 	override public function onFocus():Void
 	{
-		if (!paused) {
+		if (!paused && FlxG.autoPause) {
 			inst.resume();
 			vocals.resume();
 		}
@@ -1027,7 +1027,7 @@ class PlayState extends MusicBeatState
 	@:dox(hide)
 	override public function onFocusLost():Void
 	{
-		if (!paused) {
+		if (!paused && FlxG.autoPause) {
 			inst.pause();
 			vocals.pause();
 		}

--- a/source/funkin/game/PlayState.hx
+++ b/source/funkin/game/PlayState.hx
@@ -1015,13 +1015,22 @@ class PlayState extends MusicBeatState
 	@:dox(hide)
 	override public function onFocus():Void
 	{
+		if (!paused) {
+			inst.resume();
+			vocals.resume();
+		}
 		scripts.call("onFocus");
+		updateDiscordPresence();
 		super.onFocus();
 	}
 
 	@:dox(hide)
 	override public function onFocusLost():Void
 	{
+		if (!paused) {
+			inst.pause();
+			vocals.pause();
+		}
 		scripts.call("onFocusLost");
 		updateDiscordPresence();
 		super.onFocusLost();


### PR DESCRIPTION
If you freeze the game (the window looses focus) the discord rpc time left doesn't stop since the rpc function checks if inst is paused, but since it doesn't stop the funkin timer continues
This fix is to make it actually pause when loosing focus
Yes, tested