### PR TITLE
Implement `hxvlc`.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -25,6 +25,9 @@ jobs:
             export/release/linux/obj/
           restore-keys: |
             cache-build-linux
+      - name: Installing LibVLC
+        run: |
+          sudo apt-get install libvlc-dev libvlccore-dev
       - name: Installing/Updating libraries
         run: |
           haxe -cp commandline -D analyzer-optimize --run Main setup

--- a/libs.xml
+++ b/libs.xml
@@ -16,6 +16,7 @@
 
 	<!-- Documentation and other features -->
 	<lib name="away3d" />
+	<!-- <lib name="dox" /> -->
 	<lib name="format" />
 	<lib name="markdown" />
 </libraries>

--- a/libs.xml
+++ b/libs.xml
@@ -1,23 +1,21 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <libraries>
-    <!-- Flixel -->
-    <git name="flixel" url="https://github.com/FNF-CNE-Devs/flixel"/>
-    <git name="flixel-addons" url="https://github.com/FNF-CNE-Devs/flixel-addons"/>
+	<!-- OpenFL & Lime (Required for Flixel) -->
+	<lib name="openfl" />
+	<lib name="lime" />
 
-    <!-- Other Libraries -->
+	<!-- Flixel -->
+	<git name="flixel" url="https://github.com/FNF-CNE-Devs/flixel" />
+	<git name="flixel-addons" url="https://github.com/FNF-CNE-Devs/flixel-addons" />
+
+	<!-- Other Libraries -->
 	<git name="hscript-improved" url="https://www.github.com/FNF-CNE-Devs/hscript-improved" ref="custom-classes" />
-    <git name="discord-rpc" url="https://github.com/Aidan63/linc_discord-rpc"/>
-	<git name="flxanimate" url="https://github.com/FNF-CNE-Devs/flxanimate/" />
-	<git name="hxvlc" url="https://github.com/MAJigsaw77/hxvlc"/>
+	<git name="discord-rpc" url="https://github.com/Aidan63/linc_discord-rpc" />
+	<git name="flxanimate" url="https://github.com/FNF-CNE-Devs/flxanimate" />
+	<git name="hxvlc" url="https://github.com/MAJigsaw77/hxvlc" />
 
 	<!-- Documentation and other features -->
-    <lib name="dox"/>
-    <lib name="away3d" />
+	<lib name="away3d" />
 	<lib name="format" />
 	<lib name="markdown" />
-	<lib name="hxcpp-debug-server" />
-
-    <!-- OpenFL & Lime (Required for Flixel) -->
-    <lib name="openfl" />
-    <lib name="lime" />
 </libraries>

--- a/libs.xml
+++ b/libs.xml
@@ -8,8 +8,7 @@
 	<git name="hscript-improved" url="https://www.github.com/FNF-CNE-Devs/hscript-improved" ref="custom-classes" />
     <git name="discord-rpc" url="https://github.com/Aidan63/linc_discord-rpc"/>
 	<git name="flxanimate" url="https://github.com/FNF-CNE-Devs/flxanimate/" />
-
-	<git name="hxCodec-cne" url="https://github.com/FNF-CNE-Devs/hxCodec-cne"/>
+	<git name="hxvlc" url="https://github.com/MAJigsaw77/hxvlc"/>
 
 	<!-- Documentation and other features -->
     <lib name="dox"/>

--- a/project.xml
+++ b/project.xml
@@ -105,10 +105,12 @@
 
 	<!-- Fixes thing with macros -->
 	<define name="HL" if="hl"/>
-	<define name="SYS" if="desktop || hl"/>
+	<define name="SYS" if="cpp || hl || neko"/>
 
 	<!-- Comment this out to disable Discord RPC !-->
-	<define name="DISCORD_RPC" unless="web || hl || neko"/>
+	<section if="cpp">
+		<define name="DISCORD_RPC" if="desktop"/>
+	</section>
 
 	<!-- Comment this out to disable GitHub API integration !-->
 	<define name="GITHUB_API" unless="web || hl"/>
@@ -149,7 +151,9 @@
 	<define name="THREE_D_SUPPORT" />
 
 	<!-- Comment this out to disable video cutscene support, in case of compilation errors. !-->
-	<define name="VIDEO_CUTSCENES" unless="web || linux || hl" />
+	<section if="cpp">
+		<define name="VIDEO_CUTSCENES" if="desktop || android" />
+	</section>
 
 	<!-- Comment this out to disable commit number on FPS -->
 	<define name="SHOW_BUILD_ON_FPS" />
@@ -170,17 +174,12 @@
 	<haxelib name="flixel-addons" />
 
 	<haxelib name="hxvlc" if="VIDEO_CUTSCENES" />
-	<section if="THREE_D_SUPPORT">
-		<haxelib name="away3d" />
-	</section>
+	<haxelib name="away3d" if="THREE_D_SUPPORT" />
 	<haxelib name="format" />
 	<haxelib name="flxanimate" />
 
-	<haxedev set='webgl' />
-
 	<haxelib name="hscript-improved" />
 	<haxelib name="discord-rpc" if="DISCORD_RPC"/>
-
 	<haxelib name="markdown" />
 
 	<haxedef name="no-deprecation-warnings"/>
@@ -200,5 +199,6 @@
 	<haxedef name="HXCPP_CHECK_POINTER" if="release" />
 	<haxedef name="HXCPP_STACK_LINE" if="release" />
 	<haxedef name="HXCPP_DEBUG_LINK" if="release" />
+
 	<haxedef name="hscriptPos" /> <!-- for logging -->
 </project>

--- a/project.xml
+++ b/project.xml
@@ -21,7 +21,6 @@
 
 	<!--The flixel preloader is not accurate in Chrome. You can use it regularly if you embed the swf into a html file
 		or you can set the actual size of your file manually at "FlxPreloaderBase-onUpdate-bytesTotal"-->
-	<!-- <app preloader="Preloader" resizable="true" /> -->
 	<app preloader="flixel.system.FlxPreloader" />
 
 	<!--Minimum without FLX_NO_GAMEPAD: 11.8, without FLX_NO_NATIVE_CURSOR: 11.2-->
@@ -53,11 +52,10 @@
 	<set name="BUILD_DIR" value="export/release-32bit" if="32bit" unless="debug" />
 	<set name="BUILD_DIR" value="latest/" if="beta" />
 
-	<classpath name="source" />
+	<source name="source" />
 
 	<define name="PRELOAD_ALL" unless="web" />
 	<define name="NO_PRELOAD_ALL" unless="PRELOAD_ALL"/>
-
 
 	<library name="assets"    preload="true"  if="PRELOAD_ALL"/>
 	<library name="assets"    preload="false" if="NO_PRELOAD_ALL" />
@@ -74,16 +72,10 @@
 
 	<haxeflag name="--macro" value="funkin.backend.system.macros.NewHaxeWarning.warn()" />
 
-	<!--Enable the Flixel core recording system-->
-	<!--<haxedef name="FLX_RECORD" />-->
-
 	<haxedef name="FLX_NO_FOCUS_LOST_SCREEN" />
 
 	<!--Disable the Flixel core debugger. Automatically gets set whenever you compile in release mode!-->
 	<haxedef name="FLX_NO_DEBUG" unless="debug" />
-
-	<!--Enable this for Nape release builds for a serious performance improvement-->
-	<haxedef name="NAPE_RELEASE_BUILD" unless="debug" />
 
 	<!-- _________________________________ Custom _______________________________ -->
 
@@ -177,7 +169,7 @@
 	<haxelib name="flixel" />
 	<haxelib name="flixel-addons" />
 
-	<haxelib name="hxCodec-cne" if="VIDEO_CUTSCENES" />
+	<haxelib name="hxvlc" if="VIDEO_CUTSCENES" />
 	<section if="THREE_D_SUPPORT">
 		<haxelib name="away3d" />
 	</section>

--- a/source/funkin/backend/system/macros/ScriptsMacro.hx
+++ b/source/funkin/backend/system/macros/ScriptsMacro.hx
@@ -21,7 +21,7 @@ class ScriptsMacro {
 			"flixel.addons.util",
 			// OTHER LIBRARIES & STUFF
 			"away3d", "flx3d",
-			#if VIDEO_CUTSCENES "hxcodec.flixel", "hxcodec.openfl", "hxcodec.lime", #end
+			#if VIDEO_CUTSCENES "hxvlc.flixel", "hxvlc.openfl", #end
 			// BASE HAXE
 			"DateTools", "EReg", "Lambda", "StringBuf", "haxe.crypto", "haxe.display", "haxe.exceptions", "haxe.extern", "scripting"
 		])

--- a/source/funkin/game/cutscenes/VideoCutscene.hx
+++ b/source/funkin/game/cutscenes/VideoCutscene.hx
@@ -9,7 +9,7 @@ import sys.io.File;
 import funkin.backend.FunkinText;
 import haxe.xml.Access;
 #if VIDEO_CUTSCENES
-import hxcodec.flixel.FlxVideo;
+import hxvlc.flixel.FlxVideo;
 #end
 
 /**


### PR DESCRIPTION
Comparing to `hxCodec` this includes the following things:

- Fixes the Windows `DLLs` going into the asset manifest json file.
- Disables unnecessary stuff from libvlc that aren't actually used.
- Some performance improvements.
