### PR TITLE
Fix startDialogue for scripted cutscenes

### DIFF
--- a/source/funkin/game/cutscenes/ScriptedCutscene.hx
+++ b/source/funkin/game/cutscenes/ScriptedCutscene.hx
@@ -72,7 +72,7 @@ class ScriptedCutscene extends Cutscene {
 	#if REGION
 	public function startDialogue(path:String, ?callback:Void->Void) {
 		persistentDraw = true;
-		openSubState(new VideoCutscene(path, function() {
+		openSubState(new DialogueCutscene(path, function() {
 			if (callback != null)
 				callback();
 		}));


### PR DESCRIPTION
Before this pr, `startDialogue` loads a video cutscene instead of a dialogue cutscene so I fixed it.