### PR TITLE
Fix repeating number option

### DIFF
--- a/source/funkin/options/type/NumOption.hx
+++ b/source/funkin/options/type/NumOption.hx
@@ -49,6 +49,7 @@ class NumOption extends OptionType {
 	{
 		if(currentSelection <= min && change == -1 || currentSelection >= max && change == 1 ) return;
 		currentSelection += change*changeVal;
+		currentSelection = FlxMath.roundDecimal(currentSelection, FlxMath.getDecimals(changeVal));
 		__number.text = ': $currentSelection';
 
 		Reflect.setField(parent, optionName, currentSelection);


### PR DESCRIPTION
fixes a problem that I would come across when using the number option where if using decimal numbers, there's a chance ( i don't know what causes it exactly ) for the number to be repeated

before:

![image](https://github.com/FNF-CNE-Devs/CodenameEngine/assets/51544115/99e70bfe-ca1e-4399-ae00-8b0cbd2fe1c3)

after:

![image](https://github.com/FNF-CNE-Devs/CodenameEngine/assets/51544115/3c98513f-4521-433e-bfce-2e2804a8b27c)
