### PR TITLE
OpenFL version compatibility fix (reopen)

### DIFF
--- a/source/openfl/media/SoundChannel.hx
+++ b/source/openfl/media/SoundChannel.hx
@@ -63,7 +63,11 @@ import lime.media.AudioSource;
 	@:noCompletion private var __isValid:Bool;
 	@:noCompletion private var __soundTransform:SoundTransform;
 	#if lime
+		#if (openfl < "9.3.2")
 	@:noCompletion private var __source:AudioSource;
+		#else
+	@:noCompletion private var __audioSource:AudioSource;
+		#end
 	#end
 
 	#if openfljs
@@ -101,11 +105,19 @@ import lime.media.AudioSource;
 		#if lime
 		if (source != null)
 		{
+			#if (openfl < "9.3.2")
 			__source = source;
 			__source.onComplete.add(source_onComplete);
 			__isValid = true;
 
 			__source.play();
+			#else
+			__audioSource = source;
+			__audioSource.onComplete.add(source_onComplete);
+			__isValid = true;
+
+			__audioSource.play();
+			#end
 		}
 		#end
 
@@ -122,7 +134,11 @@ import lime.media.AudioSource;
 		if (!__isValid) return;
 
 		#if lime
+			#if (openfl < "9.3.2")
 		__source.stop();
+			#else
+		__audioSource.stop();
+			#end
 		#end
 		__dispose();
 	}
@@ -132,9 +148,15 @@ import lime.media.AudioSource;
 		if (!__isValid) return;
 
 		#if lime
+			#if (openfl < "9.3.2")
 		__source.onComplete.remove(source_onComplete);
 		__source.dispose();
 		__source = null;
+			#else
+		__audioSource.onComplete.remove(source_onComplete);
+		__audioSource.dispose();
+		__audioSource = null;
+			#end
 		#end
 		__isValid = false;
 	}
@@ -150,7 +172,11 @@ import lime.media.AudioSource;
 		if (!__isValid) return 0;
 
 		#if lime
+			#if (openfl < "9.3.2")
 		return __source.currentTime + __source.offset;
+			#else
+		return __audioSource.currentTime + __audioSource.offset;
+			#end
 		#else
 		return 0;
 		#end
@@ -161,7 +187,11 @@ import lime.media.AudioSource;
 		if (!__isValid) return 0;
 
 		#if lime
+			#if (openfl < "9.3.2")
 		__source.currentTime = value - __source.offset;
+			#else
+		__audioSource.currentTime = value - __audioSource.offset;
+			#end
 		#end
 		return value;
 	}
@@ -171,7 +201,11 @@ import lime.media.AudioSource;
 		if (!__isValid) return 1;
 
 		#if lime
+			#if (openfl < "9.3.2")
 		return __source.pitch;
+			#else
+		return __audioSource.pitch;
+			#end
 		#else
 		return 1;
 		#end
@@ -182,7 +216,11 @@ import lime.media.AudioSource;
 		if (!__isValid) return 1;
 
 		#if lime
+			#if (openfl < "9.3.2")
 		__source.pitch = value;
+			#else
+		__audioSource.pitch = value;
+			#end
 		#end
 		return value;
 	}
@@ -209,13 +247,21 @@ import lime.media.AudioSource;
 			if (__isValid)
 			{
 				#if lime
+					#if (openfl < "9.3.2")
 				__source.gain = volume;
 
 				var position = __source.position;
 				position.x = pan;
 				position.z = -1 * Math.sqrt(1 - Math.pow(pan, 2));
 				__source.position = position;
+					#else
+				__audioSource.gain = volume;
 
+				var position = __audioSource.position;
+				position.x = pan;
+				position.z = -1 * Math.sqrt(1 - Math.pow(pan, 2));
+				__audioSource.position = position;
+					#end
 				return value;
 				#end
 			}

--- a/source/openfl/media/SoundChannel.hx
+++ b/source/openfl/media/SoundChannel.hx
@@ -63,7 +63,11 @@ import lime.media.AudioSource;
 	@:noCompletion private var __isValid:Bool;
 	@:noCompletion private var __soundTransform:SoundTransform;
 	#if lime
+	#if (openfl < "9.3.2")
 	@:noCompletion private var __source:AudioSource;
+	#else
+	@:noCompletion private var __audioSource:AudioSource;
+	#end
 	#end
 
 	#if openfljs
@@ -101,11 +105,11 @@ import lime.media.AudioSource;
 		#if lime
 		if (source != null)
 		{
-			__source = source;
-			__source.onComplete.add(source_onComplete);
+			setAudioSource(source);
+			getAudioSource().onComplete.add(source_onComplete);
 			__isValid = true;
 
-			__source.play();
+			getAudioSource().play();
 		}
 		#end
 
@@ -122,7 +126,7 @@ import lime.media.AudioSource;
 		if (!__isValid) return;
 
 		#if lime
-		__source.stop();
+		getAudioSource().stop();
 		#end
 		__dispose();
 	}
@@ -132,9 +136,9 @@ import lime.media.AudioSource;
 		if (!__isValid) return;
 
 		#if lime
-		__source.onComplete.remove(source_onComplete);
-		__source.dispose();
-		__source = null;
+		getAudioSource().onComplete.remove(source_onComplete);
+		getAudioSource().dispose();
+		setAudioSource(null);
 		#end
 		__isValid = false;
 	}
@@ -150,7 +154,7 @@ import lime.media.AudioSource;
 		if (!__isValid) return 0;
 
 		#if lime
-		return __source.currentTime + __source.offset;
+		return getAudioSource().currentTime + getAudioSource().offset;
 		#else
 		return 0;
 		#end
@@ -161,7 +165,7 @@ import lime.media.AudioSource;
 		if (!__isValid) return 0;
 
 		#if lime
-		__source.currentTime = value - __source.offset;
+		getAudioSource().currentTime = value - getAudioSource().offset;
 		#end
 		return value;
 	}
@@ -171,7 +175,7 @@ import lime.media.AudioSource;
 		if (!__isValid) return 1;
 
 		#if lime
-		return __source.pitch;
+		return getAudioSource().pitch;
 		#else
 		return 1;
 		#end
@@ -182,7 +186,7 @@ import lime.media.AudioSource;
 		if (!__isValid) return 1;
 
 		#if lime
-		__source.pitch = value;
+		getAudioSource().pitch = value;
 		#end
 		return value;
 	}
@@ -209,12 +213,12 @@ import lime.media.AudioSource;
 			if (__isValid)
 			{
 				#if lime
-				__source.gain = volume;
+				getAudioSource().gain = volume;
 
-				var position = __source.position;
+				var position = getAudioSource().position;
 				position.x = pan;
 				position.z = -1 * Math.sqrt(1 - Math.pow(pan, 2));
-				__source.position = position;
+				getAudioSource().position = position;
 
 				return value;
 				#end
@@ -231,6 +235,25 @@ import lime.media.AudioSource;
 
 		__dispose();
 		dispatchEvent(new Event(Event.SOUND_COMPLETE));
+	}
+
+	// Version-independent audioSource getter & setter (in order to be flexible in future OpenFL versions)
+	@:noCompletion private function getAudioSource():AudioSource
+	{
+		#if (openfl < "9.3.2")
+		return __source;
+		#else
+		return __audioSource;
+		#end
+	}
+
+	@:noCompletion private function setAudioSource(src:AudioSource):Void
+	{
+		#if (openfl < "9.3.2")
+		__source = src;
+		#else
+		__audioSource = src;
+		#end
 	}
 }
 #else

--- a/source/openfl/media/SoundChannel.hx
+++ b/source/openfl/media/SoundChannel.hx
@@ -64,6 +64,7 @@ import lime.media.AudioSource;
 	@:noCompletion private var __soundTransform:SoundTransform;
 	#if lime
 	@:noCompletion private var __source:AudioSource;
+	@:noCompletion private var __audioSource(get, set):AudioSource;
 	#end
 
 	#if openfljs
@@ -231,6 +232,14 @@ import lime.media.AudioSource;
 
 		__dispose();
 		dispatchEvent(new Event(Event.SOUND_COMPLETE));
+	}
+
+	function set___audioSource(value:AudioSource):AudioSource {
+		return __source = value;
+	}
+
+	function get___audioSource():AudioSource {
+		return __source;
 	}
 }
 #else

--- a/source/openfl/media/SoundChannel.hx
+++ b/source/openfl/media/SoundChannel.hx
@@ -63,11 +63,7 @@ import lime.media.AudioSource;
 	@:noCompletion private var __isValid:Bool;
 	@:noCompletion private var __soundTransform:SoundTransform;
 	#if lime
-	#if (openfl < "9.3.2")
 	@:noCompletion private var __source:AudioSource;
-	#else
-	@:noCompletion private var __audioSource:AudioSource;
-	#end
 	#end
 
 	#if openfljs
@@ -105,11 +101,11 @@ import lime.media.AudioSource;
 		#if lime
 		if (source != null)
 		{
-			setAudioSource(source);
-			getAudioSource().onComplete.add(source_onComplete);
+			__source = source;
+			__source.onComplete.add(source_onComplete);
 			__isValid = true;
 
-			getAudioSource().play();
+			__source.play();
 		}
 		#end
 
@@ -126,7 +122,7 @@ import lime.media.AudioSource;
 		if (!__isValid) return;
 
 		#if lime
-		getAudioSource().stop();
+		__source.stop();
 		#end
 		__dispose();
 	}
@@ -136,9 +132,9 @@ import lime.media.AudioSource;
 		if (!__isValid) return;
 
 		#if lime
-		getAudioSource().onComplete.remove(source_onComplete);
-		getAudioSource().dispose();
-		setAudioSource(null);
+		__source.onComplete.remove(source_onComplete);
+		__source.dispose();
+		__source = null;
 		#end
 		__isValid = false;
 	}
@@ -154,7 +150,7 @@ import lime.media.AudioSource;
 		if (!__isValid) return 0;
 
 		#if lime
-		return getAudioSource().currentTime + getAudioSource().offset;
+		return __source.currentTime + __source.offset;
 		#else
 		return 0;
 		#end
@@ -165,7 +161,7 @@ import lime.media.AudioSource;
 		if (!__isValid) return 0;
 
 		#if lime
-		getAudioSource().currentTime = value - getAudioSource().offset;
+		__source.currentTime = value - __source.offset;
 		#end
 		return value;
 	}
@@ -175,7 +171,7 @@ import lime.media.AudioSource;
 		if (!__isValid) return 1;
 
 		#if lime
-		return getAudioSource().pitch;
+		return __source.pitch;
 		#else
 		return 1;
 		#end
@@ -186,7 +182,7 @@ import lime.media.AudioSource;
 		if (!__isValid) return 1;
 
 		#if lime
-		getAudioSource().pitch = value;
+		__source.pitch = value;
 		#end
 		return value;
 	}
@@ -213,12 +209,12 @@ import lime.media.AudioSource;
 			if (__isValid)
 			{
 				#if lime
-				getAudioSource().gain = volume;
+				__source.gain = volume;
 
-				var position = getAudioSource().position;
+				var position = __source.position;
 				position.x = pan;
 				position.z = -1 * Math.sqrt(1 - Math.pow(pan, 2));
-				getAudioSource().position = position;
+				__source.position = position;
 
 				return value;
 				#end
@@ -235,25 +231,6 @@ import lime.media.AudioSource;
 
 		__dispose();
 		dispatchEvent(new Event(Event.SOUND_COMPLETE));
-	}
-
-	// Version-independent audioSource getter & setter (in order to be flexible in future OpenFL versions)
-	@:noCompletion private function getAudioSource():AudioSource
-	{
-		#if (openfl < "9.3.2")
-		return __source;
-		#else
-		return __audioSource;
-		#end
-	}
-
-	@:noCompletion private function setAudioSource(src:AudioSource):Void
-	{
-		#if (openfl < "9.3.2")
-		__source = src;
-		#else
-		__audioSource = src;
-		#end
 	}
 }
 #else

--- a/source/openfl/media/SoundChannel.hx
+++ b/source/openfl/media/SoundChannel.hx
@@ -63,11 +63,7 @@ import lime.media.AudioSource;
 	@:noCompletion private var __isValid:Bool;
 	@:noCompletion private var __soundTransform:SoundTransform;
 	#if lime
-		#if (openfl < "9.3.2")
 	@:noCompletion private var __source:AudioSource;
-		#else
-	@:noCompletion private var __audioSource:AudioSource;
-		#end
 	#end
 
 	#if openfljs
@@ -105,19 +101,11 @@ import lime.media.AudioSource;
 		#if lime
 		if (source != null)
 		{
-			#if (openfl < "9.3.2")
 			__source = source;
 			__source.onComplete.add(source_onComplete);
 			__isValid = true;
 
 			__source.play();
-			#else
-			__audioSource = source;
-			__audioSource.onComplete.add(source_onComplete);
-			__isValid = true;
-
-			__audioSource.play();
-			#end
 		}
 		#end
 
@@ -134,11 +122,7 @@ import lime.media.AudioSource;
 		if (!__isValid) return;
 
 		#if lime
-			#if (openfl < "9.3.2")
 		__source.stop();
-			#else
-		__audioSource.stop();
-			#end
 		#end
 		__dispose();
 	}
@@ -148,15 +132,9 @@ import lime.media.AudioSource;
 		if (!__isValid) return;
 
 		#if lime
-			#if (openfl < "9.3.2")
 		__source.onComplete.remove(source_onComplete);
 		__source.dispose();
 		__source = null;
-			#else
-		__audioSource.onComplete.remove(source_onComplete);
-		__audioSource.dispose();
-		__audioSource = null;
-			#end
 		#end
 		__isValid = false;
 	}
@@ -172,11 +150,7 @@ import lime.media.AudioSource;
 		if (!__isValid) return 0;
 
 		#if lime
-			#if (openfl < "9.3.2")
 		return __source.currentTime + __source.offset;
-			#else
-		return __audioSource.currentTime + __audioSource.offset;
-			#end
 		#else
 		return 0;
 		#end
@@ -187,11 +161,7 @@ import lime.media.AudioSource;
 		if (!__isValid) return 0;
 
 		#if lime
-			#if (openfl < "9.3.2")
 		__source.currentTime = value - __source.offset;
-			#else
-		__audioSource.currentTime = value - __audioSource.offset;
-			#end
 		#end
 		return value;
 	}
@@ -201,11 +171,7 @@ import lime.media.AudioSource;
 		if (!__isValid) return 1;
 
 		#if lime
-			#if (openfl < "9.3.2")
 		return __source.pitch;
-			#else
-		return __audioSource.pitch;
-			#end
 		#else
 		return 1;
 		#end
@@ -216,11 +182,7 @@ import lime.media.AudioSource;
 		if (!__isValid) return 1;
 
 		#if lime
-			#if (openfl < "9.3.2")
 		__source.pitch = value;
-			#else
-		__audioSource.pitch = value;
-			#end
 		#end
 		return value;
 	}
@@ -247,21 +209,13 @@ import lime.media.AudioSource;
 			if (__isValid)
 			{
 				#if lime
-					#if (openfl < "9.3.2")
 				__source.gain = volume;
 
 				var position = __source.position;
 				position.x = pan;
 				position.z = -1 * Math.sqrt(1 - Math.pow(pan, 2));
 				__source.position = position;
-					#else
-				__audioSource.gain = volume;
 
-				var position = __audioSource.position;
-				position.x = pan;
-				position.z = -1 * Math.sqrt(1 - Math.pow(pan, 2));
-				__audioSource.position = position;
-					#end
 				return value;
 				#end
 			}


### PR DESCRIPTION
(reopen of #249 with a new solution)

Uses (compiles) "__source" or "__audioSource" variable depending of the OpenFL version, in order to not break FlxSound.