### PR TITLE
FunkinParentDisabler: Prevents camera movement, shaking, and update flash

### DIFF
--- a/source/funkin/backend/utils/FunkinParentDisabler.hx
+++ b/source/funkin/backend/utils/FunkinParentDisabler.hx
@@ -32,8 +32,8 @@ class FunkinParentDisabler extends FlxBasic {
 			FlxTimer.globalManager._timers = [];
 
 			// cameras
-			__cameras = [for(c in FlxG.cameras.list) if (c.followEnabled) c];
-			for(c in __cameras) c.followEnabled = false;
+			__cameras = [for(c in FlxG.cameras.list) if (c.active) c];
+			for(c in __cameras) c.active = false;
 
 			// sounds
 			__sounds = [for(s in FlxG.sound.list) if (s.playing) s];
@@ -61,7 +61,7 @@ class FunkinParentDisabler extends FlxBasic {
 				for(t in __tweens) FlxTween.globalManager._tweens.push(t);
 				for(t in __timers) FlxTimer.globalManager._timers.push(t);
 			}
-			for(c in __cameras) c.followEnabled = true;
+			for(c in __cameras) c.active = true;
 			for(s in __sounds) s.play();
 		}
 	}


### PR DESCRIPTION
Well, as the title mentions, this is a simple change to the FunkinParentDisabler class, which makes it so that when you are, for example, in the pause menu, the camera, in addition to stopping following, stops shaking and stops updating the flash