### PR TITLE
FunkinParentDisabler: Fix camera not updating its size

### DIFF
--- a/source/funkin/backend/utils/FunkinParentDisabler.hx
+++ b/source/funkin/backend/utils/FunkinParentDisabler.hx
@@ -41,7 +41,9 @@ class FunkinParentDisabler extends FlxBasic {
 		}
 	}
 
-	public override function update(elapsed:Float) {}
+	public override function update(elapsed:Float) {
+		@:privateAccess for(c in __cameras) c.updateFlashSpritePosition();
+	}
 	public override function draw() {}
 
 	public function reset() {


### PR DESCRIPTION
In my previous pull request I proposed a way to prevent the camera from continuing to update but it also brought another bug preventing the camera from updating its size when changing the window size
Now in this pull request I have another simple change that should fix it (I hope this doesn't give us another bug lol)
### Before:
![image](https://github.com/FNF-CNE-Devs/CodenameEngine/assets/81833766/53568065-d83c-4eb1-8880-c07fbb99b7de)
### After:
![image](https://github.com/FNF-CNE-Devs/CodenameEngine/assets/81833766/424f7057-1f1b-4d82-a662-04c483b6da98)
