### PR TITLE
Don't create the vocals' waveform if they weren't loaded

### DIFF
--- a/source/funkin/editors/charter/Charter.hx
+++ b/source/funkin/editors/charter/Charter.hx
@@ -611,7 +611,8 @@ class Charter extends UIState {
 		var wavesToGenerate:Array<{name:String, sound:FlxSound}> = [
 			{name: "Inst.ogg", sound: FlxG.sound.music},
 		];
-		if (PlayState.SONG.meta.needsVoices != false) 
+		@:privateAccess
+		if (vocals._sound != null && PlayState.SONG.meta.needsVoices != false) 
 			wavesToGenerate.push({name: "Voices.ogg", sound: vocals});
 
 		for (strumLine in strumLines)


### PR DESCRIPTION
Fixes that one infamous crash on the charter that forces people to use older versions of CNE.