### PR TITLE
[Unix Build Actions] Do not preserve directory tree when packing tar

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           haxelib run lime build linux
       - name: Tar files
-        run: tar -zcvf CodenameEngine.tar.gz export/release/linux/bin
+        run: tar -zcvf CodenameEngine.tar.gz -C export/release/linux/bin .
       - name: Uploading artifact (entire build)
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           haxelib run lime build mac
       - name: Tar files
-        run: tar -zcvf CodenameEngine.tar.gz export/release/macos/bin
+        run: tar -zcvf CodenameEngine.tar.gz -C export/release/macos/bin .
       - name: Uploading artifact (entire build)
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
Originally https://github.com/FNF-CNE-Devs/CodenameEngine/pull/333 but now does the same thing for MacOS too