### PR TITLE
Fix Null object Reference

### DIFF
--- a/source/funkin/game/PlayState.hx
+++ b/source/funkin/game/PlayState.hx
@@ -1260,7 +1260,7 @@ class PlayState extends MusicBeatState
 				if (Conductor.songPosition >= 0)
 					startSong();
 			}
-		} else {
+		} else if (!startingSong && FlxG.sound.music != null) {
 			var instTime = FlxG.sound.music.time;
 			var isOffsync = vocals.time != instTime || [for(strumLine in strumLines.members) strumLine.vocals.time != instTime].contains(true);
 			__vocalOffsetViolation = Math.max(0, __vocalOffsetViolation + (isOffsync ? elapsed : -elapsed / 2));


### PR DESCRIPTION
When you pause in a specific time in the countdown (when the countdown is finishing) it crashs.

I just added a null check for the song to fix it.