### PR TITLE
Alphabet Bold Numbers Fix (reopen)

### DIFF
--- a/assets/data/alphabet.xml
+++ b/assets/data/alphabet.xml
@@ -28,6 +28,16 @@
 		<letter char="X"        anim="X bold" />
 		<letter char="Y"        anim="Y bold" />
 		<letter char="Z"        anim="Z bold" />
+		<letter char="0"        anim="0 bold" />
+		<letter char="1"        anim="1 bold" />
+		<letter char="2"        anim="2 bold" />
+		<letter char="3"        anim="3 bold" />
+		<letter char="4"        anim="4 bold" />
+		<letter char="5"        anim="5 bold" />
+		<letter char="6"        anim="6 bold" />
+		<letter char="7"        anim="7 bold" />
+		<letter char="8"        anim="8 bold" />
+		<letter char="9"        anim="9 bold" />
 		<letter char=">"        anim="> Bold" />
 	</bold>
 	<normal spritesheet="menus/alphabet">


### PR DESCRIPTION
# Fixed Bold Numbers not showing in TitleState and Credits.

I've noticed that Bold numbers are present in the Spritesheet, but unspecified on `alphabet.xml`, so that why it wasn't showing up.

# Before
![Missing Numbers on Usernames](https://github.com/user-attachments/assets/d332e599-b5b3-4951-a5ce-dab2a646b436)

# After
![Visible Numbers](https://github.com/user-attachments/assets/f02c77ab-3f7c-4cb0-8954-d7bf14289700)
