### PR TITLE
Load every options file from all asset libraries

### DIFF
--- a/source/funkin/options/OptionsMenu.hx
+++ b/source/funkin/options/OptionsMenu.hx
@@ -65,22 +65,21 @@ class OptionsMenu extends TreeMenu {
 			}
 		})]);
 
-		var xmlPath = Paths.xml("config/options");
-		for(source in [funkin.backend.assets.AssetsLibraryList.AssetSource.SOURCE, funkin.backend.assets.AssetsLibraryList.AssetSource.MODS]) {
-			if (Paths.assetsTree.existsSpecific(xmlPath, "TEXT", source)) {
+		for (i in funkin.backend.assets.ModsFolder.getLoadedMods()) {
+			var xmlPath = Paths.xml('config/options/LIB_$i');
+
+			if (Paths.assetsTree.existsSpecific(xmlPath, "TEXT")) {
 				var access:Access = null;
 				try {
-					access = new Access(Xml.parse(Paths.assetsTree.getSpecificAsset(xmlPath, "TEXT", source)));
+					access = new Access(Xml.parse(Paths.assetsTree.getSpecificAsset(xmlPath, "TEXT")));
 				} catch(e) {
 					Logs.trace('Error while parsing options.xml: ${Std.string(e)}', ERROR);
 				}
-
 				if (access != null)
 					for(o in parseOptionsFromXML(access))
 						main.add(o);
 			}
 		}
-
 	}
 
 	public override function exit() {


### PR DESCRIPTION
This solves an issue I had where addons would replace the mod options.

Instead of just loading the options from the top-most library + source, it gets the options from every library.

before (only the `addon1` options are shown)
![image](https://github.com/user-attachments/assets/f2ee921d-fc33-4d8b-bd9b-1cb01ff61863)

after (now all options from every library is shown)
![image](https://github.com/user-attachments/assets/d9dad366-4c3a-47e0-89ca-11984a91dba5)

