### PR TITLE
Added optional Extra Data support to ModState/ModSubState

### DIFF
--- a/source/funkin/backend/scripting/ModState.hx
+++ b/source/funkin/backend/scripting/ModState.hx
@@ -22,6 +22,7 @@ class ModState extends MusicBeatState {
 	public function new(_stateName:String, ?_data:Dynamic) {
 		if(_stateName != null && _stateName != lastName) {
 			lastName = _stateName;
+			data = null;
 		}
 
 		if(_data != null)

--- a/source/funkin/backend/scripting/ModState.hx
+++ b/source/funkin/backend/scripting/ModState.hx
@@ -6,16 +6,14 @@ class ModState extends MusicBeatState {
 
 	//New Constructor
 	public function new(stateName:String, ?jsonData:Dynamic = null) {
-		
 		//State Name
-		if (stateName != null){
+		if (stateName != null)
 			lastName = stateName;
-		}
-		
+
 		//Extra Data
-		if(jsonData != null){
+		if(jsonData != null)
 			data = jsonData;
-		}
+
 		super(true, lastName);
 	}
 }

--- a/source/funkin/backend/scripting/ModState.hx
+++ b/source/funkin/backend/scripting/ModState.hx
@@ -1,9 +1,24 @@
 package funkin.backend.scripting;
 
 class ModState extends MusicBeatState {
-	public static var lastName:String = null;
-	public static var data:Dynamic = null; //Use this to pass data between states (Optional)
 
+	/**
+	* Name of HScript file in assets/data/states.
+	*/
+	public static var lastName:String = null;
+	
+	/**
+	* Optional extra data.
+	*/
+	public static var data:Dynamic = null;
+
+	/**
+	* ModState Constructor.
+	* Inherits from MusicBeatState and allows the execution of an HScript from assets/data/states passed via parameters.
+	* 
+	* @param _stateName Name or path to a HScript file from assets/data/states.
+	* @param _data Optional extra Dynamic data passed from a previous state (JSON suggested).
+	*/
 	public function new(_stateName:String, ?_data:Dynamic) {
 		if(_stateName != null && _stateName != lastName) {
 			lastName = _stateName;

--- a/source/funkin/backend/scripting/ModState.hx
+++ b/source/funkin/backend/scripting/ModState.hx
@@ -2,17 +2,16 @@ package funkin.backend.scripting;
 
 class ModState extends MusicBeatState {
 	public static var lastName:String = null;
-	public static var data:Dynamic = [];
+	public static var data:Dynamic = null;
 
-	//New Constructor
-	public function new(stateName:String, ?jsonData:Dynamic = null) {
-		//State Name
-		if (stateName != null)
-			lastName = stateName;
+	public function new(_stateName:String, ?_data:Dynamic) {
+		if(_stateName != null && _stateName != lastName) {
+			lastName = _stateName;
+			data = null;
+		}
 
-		//Extra Data
-		if(jsonData != null)
-			data = jsonData;
+		if(_data != null)
+			data = _data;
 
 		super(true, lastName);
 	}

--- a/source/funkin/backend/scripting/ModState.hx
+++ b/source/funkin/backend/scripting/ModState.hx
@@ -2,7 +2,7 @@ package funkin.backend.scripting;
 
 class ModState extends MusicBeatState {
 	public static var lastName:String = null;
-	public static var data:Dynamic = null;
+	public static var data:Dynamic = null; //Use this to pass data between states (Optional)
 
 	public function new(_stateName:String, ?_data:Dynamic) {
 		if(_stateName != null && _stateName != lastName) {

--- a/source/funkin/backend/scripting/ModState.hx
+++ b/source/funkin/backend/scripting/ModState.hx
@@ -2,9 +2,20 @@ package funkin.backend.scripting;
 
 class ModState extends MusicBeatState {
 	public static var lastName:String = null;
-	public function new(stateName:String) {
-		if (stateName != null)
+	public static var data:Dynamic = [];
+
+	//New Constructor
+	public function new(stateName:String, ?jsonData:Dynamic = null) {
+		
+		//State Name
+		if (stateName != null){
 			lastName = stateName;
+		}
+		
+		//Extra Data
+		if(jsonData != null){
+			data = jsonData;
+		}
 		super(true, lastName);
 	}
 }

--- a/source/funkin/backend/scripting/ModState.hx
+++ b/source/funkin/backend/scripting/ModState.hx
@@ -22,7 +22,6 @@ class ModState extends MusicBeatState {
 	public function new(_stateName:String, ?_data:Dynamic) {
 		if(_stateName != null && _stateName != lastName) {
 			lastName = _stateName;
-			data = null;
 		}
 
 		if(_data != null)

--- a/source/funkin/backend/scripting/ModState.hx
+++ b/source/funkin/backend/scripting/ModState.hx
@@ -6,28 +6,33 @@ class ModState extends MusicBeatState {
 	* Name of HScript file in assets/data/states.
 	*/
 	public static var lastName:String = null;
-	
+
 	/**
 	* Optional extra data.
 	*/
-	public static var data:Dynamic = null;
+	public var data:Dynamic = null;
+	/**
+	* Last Optional extra data.
+	*/
+	public static var lastData:Dynamic = null;
 
 	/**
 	* ModState Constructor.
 	* Inherits from MusicBeatState and allows the execution of an HScript from assets/data/states passed via parameters.
-	* 
+	*
 	* @param _stateName Name or path to a HScript file from assets/data/states.
 	* @param _data Optional extra Dynamic data passed from a previous state (JSON suggested).
 	*/
 	public function new(_stateName:String, ?_data:Dynamic) {
 		if(_stateName != null && _stateName != lastName) {
 			lastName = _stateName;
-			data = null;
+			lastData = null;
 		}
 
 		if(_data != null)
-			data = _data;
+			lastData = _data;
 
+		data = lastData;
 		super(true, lastName);
 	}
 }

--- a/source/funkin/backend/scripting/ModState.hx
+++ b/source/funkin/backend/scripting/ModState.hx
@@ -6,15 +6,15 @@ class ModState extends MusicBeatState {
 	* Name of HScript file in assets/data/states.
 	*/
 	public static var lastName:String = null;
+	/**
+	* Last Optional extra data.
+	*/
+	public static var lastData:Dynamic = null;
 
 	/**
 	* Optional extra data.
 	*/
 	public var data:Dynamic = null;
-	/**
-	* Last Optional extra data.
-	*/
-	public static var lastData:Dynamic = null;
 
 	/**
 	* ModState Constructor.

--- a/source/funkin/backend/scripting/ModSubState.hx
+++ b/source/funkin/backend/scripting/ModSubState.hx
@@ -6,16 +6,14 @@ class ModSubState extends MusicBeatSubstate {
 
 	//New Constructor
 	public function new(stateName:String, ?jsonData:Dynamic = null) {
-		
 		//State Name
-		if (stateName != null){
+		if (stateName != null)
 			lastName = stateName;
-		}
-		
+
 		//Extra Data
-		if(jsonData != null){
+		if(jsonData != null)
 			data = jsonData;
-		}
+
 		super(true, lastName);
 	}
 }

--- a/source/funkin/backend/scripting/ModSubState.hx
+++ b/source/funkin/backend/scripting/ModSubState.hx
@@ -1,9 +1,24 @@
 package funkin.backend.scripting;
 
 class ModSubState extends MusicBeatSubstate {
-	public static var lastName:String = null;
-	public static var data:Dynamic = null; //Use this to pass info between states (Optional)
 
+	/**
+	* Name of HScript file in assets/data/states.
+	*/
+	public static var lastName:String = null;
+
+	/**
+	* Optional extra data.
+	*/
+	public static var data:Dynamic = null;
+
+	/**
+	* ModSubState Constructor.
+	* Inherits from MusicBeatSubstate and allows the execution of an HScript from assets/data/states passed via parameters.
+	* 
+	* @param _stateName Name or path to a HScript file from assets/data/states.
+	* @param _data Optional extra Dynamic data passed from a previous state (JSON suggested). 
+	*/
 	public function new(_stateName:String, ?_data:Dynamic) {
 		if(_stateName != null && _stateName != lastName) {
 			lastName = _stateName;

--- a/source/funkin/backend/scripting/ModSubState.hx
+++ b/source/funkin/backend/scripting/ModSubState.hx
@@ -2,17 +2,16 @@ package funkin.backend.scripting;
 
 class ModSubState extends MusicBeatSubstate {
 	public static var lastName:String = null;
-	public static var data:Dynamic = [];
+	public static var data:Dynamic = null;
 
-	//New Constructor
-	public function new(stateName:String, ?jsonData:Dynamic = null) {
-		//State Name
-		if (stateName != null)
-			lastName = stateName;
+	public function new(_stateName:String, ?_data:Dynamic) {
+		if(_stateName != null && _stateName != lastName) {
+			lastName = _stateName;
+			data = null;
+		}
 
-		//Extra Data
-		if(jsonData != null)
-			data = jsonData;
+		if(_data != null)
+			data = _data;
 
 		super(true, lastName);
 	}

--- a/source/funkin/backend/scripting/ModSubState.hx
+++ b/source/funkin/backend/scripting/ModSubState.hx
@@ -10,24 +10,29 @@ class ModSubState extends MusicBeatSubstate {
 	/**
 	* Optional extra data.
 	*/
-	public static var data:Dynamic = null;
+	public var data:Dynamic = null;
+	/**
+	* Last Optional extra data.
+	*/
+	public static var lastData:Dynamic = null;
 
 	/**
 	* ModSubState Constructor.
 	* Inherits from MusicBeatSubstate and allows the execution of an HScript from assets/data/states passed via parameters.
-	* 
+	*
 	* @param _stateName Name or path to a HScript file from assets/data/states.
-	* @param _data Optional extra Dynamic data passed from a previous state (JSON suggested). 
+	* @param _data Optional extra Dynamic data passed from a previous state (JSON suggested).
 	*/
 	public function new(_stateName:String, ?_data:Dynamic) {
 		if(_stateName != null && _stateName != lastName) {
 			lastName = _stateName;
-			data = null;
+			lastData = null;
 		}
 
 		if(_data != null)
-			data = _data;
+			lastData = _data;
 
+		data = lastData;
 		super(true, lastName);
 	}
 }

--- a/source/funkin/backend/scripting/ModSubState.hx
+++ b/source/funkin/backend/scripting/ModSubState.hx
@@ -2,9 +2,20 @@ package funkin.backend.scripting;
 
 class ModSubState extends MusicBeatSubstate {
 	public static var lastName:String = null;
-	public function new(stateName:String) {
-		if (stateName != null)
+	public static var data:Dynamic = [];
+
+	//New Constructor
+	public function new(stateName:String, ?jsonData:Dynamic = null) {
+		
+		//State Name
+		if (stateName != null){
 			lastName = stateName;
+		}
+		
+		//Extra Data
+		if(jsonData != null){
+			data = jsonData;
+		}
 		super(true, lastName);
 	}
 }

--- a/source/funkin/backend/scripting/ModSubState.hx
+++ b/source/funkin/backend/scripting/ModSubState.hx
@@ -22,6 +22,7 @@ class ModSubState extends MusicBeatSubstate {
 	public function new(_stateName:String, ?_data:Dynamic) {
 		if(_stateName != null && _stateName != lastName) {
 			lastName = _stateName;
+			data = null;
 		}
 
 		if(_data != null)

--- a/source/funkin/backend/scripting/ModSubState.hx
+++ b/source/funkin/backend/scripting/ModSubState.hx
@@ -22,7 +22,6 @@ class ModSubState extends MusicBeatSubstate {
 	public function new(_stateName:String, ?_data:Dynamic) {
 		if(_stateName != null && _stateName != lastName) {
 			lastName = _stateName;
-			data = null;
 		}
 
 		if(_data != null)

--- a/source/funkin/backend/scripting/ModSubState.hx
+++ b/source/funkin/backend/scripting/ModSubState.hx
@@ -6,15 +6,15 @@ class ModSubState extends MusicBeatSubstate {
 	* Name of HScript file in assets/data/states.
 	*/
 	public static var lastName:String = null;
+	/**
+	* Last Optional extra data.
+	*/
+	public static var lastData:Dynamic = null;
 
 	/**
 	* Optional extra data.
 	*/
 	public var data:Dynamic = null;
-	/**
-	* Last Optional extra data.
-	*/
-	public static var lastData:Dynamic = null;
 
 	/**
 	* ModSubState Constructor.

--- a/source/funkin/backend/scripting/ModSubState.hx
+++ b/source/funkin/backend/scripting/ModSubState.hx
@@ -2,7 +2,7 @@ package funkin.backend.scripting;
 
 class ModSubState extends MusicBeatSubstate {
 	public static var lastName:String = null;
-	public static var data:Dynamic = null;
+	public static var data:Dynamic = null; //Use this to pass info between states (Optional)
 
 	public function new(_stateName:String, ?_data:Dynamic) {
 		if(_stateName != null && _stateName != lastName) {


### PR DESCRIPTION
## First
I dont know if this is already implemented :P, feel free to reject this if i'm wrong, feel free to comment

## What i've added?

This adds support to ModStates and ModSubstates to access entry data from a previous state

## Use Case

You will use this if you have a hub state that switchState to a handler that loads assets based on incomming data, for example:

#### WorldSelectionState.hx :
- Here you will manage the user selection and then redirect to a world
- Based on Selection you will have a switch case clausule that is going to load WorldState.hx based on user selection
- Then you will do this in any case:

```haxe 
case 0:
        FlxG.switchState(new ModState('WorldState',{
                 'worldID': 0 
        })); // This will say to state to load assets based on this.data.worldID
```

#### WorldState.hx:

- Here you will have access to the data and then you going to use it like this:

```haxe 

function create(){
	loadAssets();
}

function loadAssets(){
	trace('loading assets of World' + this.data.worldID);
}
```

## Which kind of data you can pass to this.data:

```haxe 

FlxG.switchState(new ModState('substates/tutorialSubstate',{
                'indices' : [1,2,3,4,5],
                'State' : this, //Actual State
                'function': function(){
                    trace('poto');
                },
                'String': 'HelloWorld',
                'Int': 0,
                'Float': .1,
                ... 
            }));
```

You can pass all kind of data :D, including functions, you just need to be creative

## Why you need to accept this?

Why not? jk 🅰️ XD

This allows coders to create reusable code. 
I've been working with this on my projects and it is very helpful to have fast access to data from a previous state.