### PR TITLE
Add alter exclusions to HudCamera

### DIFF
--- a/source/funkin/game/HudCamera.hx
+++ b/source/funkin/game/HudCamera.hx
@@ -5,6 +5,8 @@ import flixel.math.FlxPoint;
 
 class HudCamera extends FlxCamera {
 	public var downscroll:Bool = false;
+	public var alterExclusions:Array<FlxObject> = [];
+	
 	//public override function update(elapsed:Float) {
 	//	super.update(elapsed);
 	//	// flipY = downscroll;
@@ -23,7 +25,7 @@ class HudCamera extends FlxCamera {
 
 
 	public override function alterScreenPosition(spr:FlxObject, pos:FlxPoint) {
-		if (downscroll) {
+		if (downscroll && !alterExclusions.contains(spr)) {
 			pos.set(pos.x, height - pos.y - spr.height);
 		}
 		return pos;


### PR DESCRIPTION
This will avoid having to create a new camera to add custom objects to the HUD