### PR TITLE
Make Paths.getAssetsRoot() return the source assets rather than the exported assets when using ./cne test

### DIFF
--- a/source/funkin/backend/assets/Paths.hx
+++ b/source/funkin/backend/assets/Paths.hx
@@ -171,7 +171,7 @@ class Paths
 		return FlxAtlasFrames.fromAseprite('$key.png', '$key.json');
 
 	inline static public function getAssetsRoot():String
-		return  ModsFolder.currentModFolder != null ? '${ModsFolder.modsPath}${ModsFolder.currentModFolder}' : './assets';
+		return  ModsFolder.currentModFolder != null ? '${ModsFolder.modsPath}${ModsFolder.currentModFolder}' : #if TEST_BUILD './${Main.pathBack}assets/' #else './assets' #end;
 
 	/**
 	 * Gets frames at specified path.


### PR DESCRIPTION
This fixes a bug where the chart editor and character editor save to the exported assets folder regardless of whether it is a test or release build.