### PR TITLE
fixed Beats Per Measure not being updated based on sectionBeats

### DIFF
--- a/source/funkin/backend/chart/FNFLegacyParser.hx
+++ b/source/funkin/backend/chart/FNFLegacyParser.hx
@@ -56,6 +56,9 @@ class FNFLegacyParser {
 				continue; // Yoshi Engine charts crash fix
 			}
 
+			// Update beatsPerMeasure based on sectionBeats (this was never done before and sectionBeats was entirely unused -other nex)
+			beatsPerMeasure = section.sectionBeats != null ? section.sectionBeats : data.beatsPerMeasure.getDefault(4);
+
 			if (camFocusedBF != (camFocusedBF = section.mustHitSection)) {
 				result.events.push({
 					time: curTime,


### PR DESCRIPTION
i noticed that sectionBeats was just completely unused which meant that it was never updated beatsPerMeasure and in turn, all measures were treated like they had 4 beats regardless of whether or not that was true.