### PR TITLE
Add extra charter controls

### DIFF
--- a/source/funkin/editors/charter/Charter.hx
+++ b/source/funkin/editors/charter/Charter.hx
@@ -376,7 +376,7 @@ class Charter extends UIState {
 						onSelect: _playback_back_step
 					},
 					{
-						label: "Go forward a steo",
+						label: "Go forward a step",
 						keybind: [S],
 						onSelect: _playback_forward_step
 					},

--- a/source/funkin/editors/charter/Charter.hx
+++ b/source/funkin/editors/charter/Charter.hx
@@ -341,6 +341,7 @@ class Charter extends UIState {
 					null,
 					{
 						label: "↑ Speed 25%",
+						keybind: [PERIOD],
 						onSelect: _playback_speed_raise
 					},
 					{
@@ -349,6 +350,7 @@ class Charter extends UIState {
 					},
 					{
 						label: "↓ Speed 25%",
+						keybind: [COMMA],
 						onSelect: _playback_speed_lower
 					},
 					null,
@@ -361,6 +363,22 @@ class Charter extends UIState {
 						label: "Go forward a section",
 						keybind: [D],
 						onSelect: _playback_forward
+					},
+					{
+						label: "Go to start of section",
+						keybind: [SHIFT, S],
+						onSelect: _playback_section_start
+					},
+					null,
+					{
+						label: "Go back a step",
+						keybind: [W],
+						onSelect: _playback_back_step
+					},
+					{
+						label: "Go forward a steo",
+						keybind: [S],
+						onSelect: _playback_forward_step
 					},
 					null,
 					{
@@ -1578,6 +1596,18 @@ class Charter extends UIState {
 	function _playback_forward(_) {
 		if (FlxG.sound.music.playing) return;
 		Conductor.songPosition += (Conductor.beatsPerMeasure * __crochet);
+	}
+	function _playback_section_start(_) {
+		if(FlxG.sound.music.playing) return;
+		Conductor.songPosition = (Conductor.beatsPerMeasure * (60000 / Conductor.bpm)) * curMeasure;
+	}
+	function _playback_back_step(_) {
+		if (FlxG.sound.music.playing) return;
+		Conductor.songPosition -= Conductor.stepCrochet;
+	}
+	function _playback_forward_step(_) {
+		if (FlxG.sound.music.playing) return;
+		Conductor.songPosition += Conductor.stepCrochet;
 	}
 	function _song_start(_) {
 		if (FlxG.sound.music.playing) return;

--- a/source/funkin/editors/ui/UISlider.hx
+++ b/source/funkin/editors/ui/UISlider.hx
@@ -26,6 +26,7 @@ class UISlider extends UISprite {
 
 	public var value(default, set):Float = 0;
 	public function set_value(newVal:Float):Float {
+		newVal = FlxMath.bound(newVal, segments[0].start, segments[segments.length-1].end);
 		__barProgress = __calcProgress(newVal); if (onChange != null) onChange(newVal);
 		if (valueStepper != null) valueStepper.value = newVal;
 		return value = newVal;


### PR DESCRIPTION
Adds quality of life controls to the charter.

Additions/changes:
- Youtube hotkeys (without shift) for playback speed (< and >)
- Go to start of section (Shift + S)
- Go forward and back a step (W and S)

![image](https://github.com/user-attachments/assets/973e5d60-eb45-4b8b-a1bf-357ee055b7ab)
