### PR TITLE
Fix dialogueLine next sound getting from assets/music instead of assets/sounds

### DIFF
--- a/source/funkin/game/cutscenes/DialogueCutscene.hx
+++ b/source/funkin/game/cutscenes/DialogueCutscene.hx
@@ -89,7 +89,7 @@ class DialogueCutscene extends Cutscene {
 					musicVolume: node.has.musicVolume ? (volume = Std.parseFloat(node.att.speed).getDefault(0.8)) : null,
 					changeMusic: node.has.changeMusic ? FlxG.sound.load(Paths.music(node.att.changeMusic), volume, true) : null,
 					playSound: node.has.playSound ? FlxG.sound.load(Paths.sound(node.att.playSound)) : null,
-					nextSound: node.has.nextSound ? FlxG.sound.load(Paths.music(node.att.nextSound)) : null,
+					nextSound: node.has.nextSound ? FlxG.sound.load(Paths.sound(node.att.nextSound)) : null,
 					textSound: null
 				};
 


### PR DESCRIPTION
Just a fix for an error I noticed while working on a mod where if the dialogue next sound is set by a line in dialogue.xml, it would try to grab from the music folder instead of sounds.