### PR TITLE
fix xdg-open in NixOS

### DIFF
--- a/source/funkin/backend/utils/CoolUtil.hx
+++ b/source/funkin/backend/utils/CoolUtil.hx
@@ -706,7 +706,10 @@ class CoolUtil
 	 */
 	@:noUsing public static inline function openURL(url:String) {
 		#if linux
-		Sys.command('/usr/bin/xdg-open', [url]);
+		// generally `xdg-open` should work in every distro
+		var cmd = Sys.command("xdg-open", [url]);
+		// run old command JUST IN CASE it fails, which it shouldn't
+		if (cmd != 0) cmd = Sys.command("/usr/bin/xdg-open", [url]);
 		#else
 		FlxG.openURL(url);
 		#end

--- a/source/lime/system/System.hx
+++ b/source/lime/system/System.hx
@@ -304,7 +304,10 @@ class System
 			#elseif mac
 			Sys.command("/usr/bin/open", [path]);
 			#elseif linux
-			Sys.command("/usr/bin/xdg-open", [path, "&"]);
+			// generally `xdg-open` should work in every distro
+			var cmd = Sys.command("xdg-open", [path, "&"]);
+			// run old command JUST IN CASE it fails, which it shouldn't
+			if (cmd != 0) cmd = Sys.command("/usr/bin/xdg-open", [path, "&"]);
 			#elseif (js && html5)
 			Browser.window.open(path, "_blank");
 			#elseif flash


### PR DESCRIPTION
fixes `/usr/bin/xdg-open not found` in NixOS and *potentally* BSD