### PR TITLE
judgements and combo can now be toggled off in hscript

### DIFF
--- a/source/funkin/backend/scripting/events/NoteHitEvent.hx
+++ b/source/funkin/backend/scripting/events/NoteHitEvent.hx
@@ -32,11 +32,11 @@ final class NoteHitEvent extends CancellableEvent {
 	/**
 	 * Whenever the Rating sprites should be shown or not.
 	 */
-	 public var displayRating:Null<Bool> = null;
+	public var displayRating:Null<Bool> = null;
 	/**
 	 * Whenever the Combo sprite should be shown or not (like old Week 7 patches).
 	 */
-	 public var displayCombo:Null<Bool> = null;
+	public var displayCombo:Null<Bool> = null;
 	/**
 	 * Note that has been pressed
 	 */

--- a/source/funkin/backend/scripting/events/NoteHitEvent.hx
+++ b/source/funkin/backend/scripting/events/NoteHitEvent.hx
@@ -32,11 +32,11 @@ final class NoteHitEvent extends CancellableEvent {
 	/**
 	 * Whenever the Rating sprites should be shown or not.
 	 */
-	public var displayRating:Null<Bool> = null;
+	public var displayRating:Bool;
 	/**
 	 * Whenever the Combo sprite should be shown or not (like old Week 7 patches).
 	 */
-	public var displayCombo:Null<Bool> = null;
+	public var displayCombo:Bool;
 	/**
 	 * Note that has been pressed
 	 */

--- a/source/funkin/backend/scripting/events/NoteHitEvent.hx
+++ b/source/funkin/backend/scripting/events/NoteHitEvent.hx
@@ -24,9 +24,19 @@ final class NoteHitEvent extends CancellableEvent {
 	 */
 	public var countScore:Bool = true;
 	/**
-	 * Whenever ratings should be shown or not.
+	 * Whenever ratings (Rating sprite, Digits sprites and Combo sprite) should be shown or not.
+	 *
+	 * NOTE: Whether it's `true` use `displayRating` and `displayCombo` (plus `minDigitDisplay` in the PlayState class) to change what's going to pop up!
 	 */
 	public var showRating:Null<Bool> = null;
+	/**
+	 * Whenever the Rating sprites should be shown or not.
+	 */
+	 public var displayRating:Null<Bool> = null;
+	/**
+	 * Whenever the Combo sprite should be shown or not (like old Week 7 patches).
+	 */
+	 public var displayCombo:Null<Bool> = null;
 	/**
 	 * Note that has been pressed
 	 */

--- a/source/funkin/game/PlayState.hx
+++ b/source/funkin/game/PlayState.hx
@@ -456,6 +456,20 @@ class PlayState extends MusicBeatState
 	 */
 	public var comboGroup:RotatingSpriteGroup;
 	/**
+	 * If the rating should be displayed when hitting notes.
+	 */
+	public var ratingOnPopups:Bool = true;
+	/**
+	 * Minimum Combo Count to display the combo digits.
+	 * anything less than 0 means it won't be shown
+	 */
+	public var minDigitDisplay:Int = 10;
+	/**
+	 * If the image with "COMBO" written on it should be displayed (like old Week 7 patches)
+	 * PS: this shit's useless keep it off if you don't wanna clutter the UI
+	 */
+	public var comboSpriteOnPopups:Bool = false;
+	/**
 	 * Array containing all of the note types names.
 	 */
 	public var noteTypesArray:Array<String> = [null];
@@ -1666,7 +1680,8 @@ class PlayState extends MusicBeatState
 				if (event.showRating || (event.showRating == null && event.player))
 				{
 					displayCombo(event);
-					displayRating(event.rating, event);
+					if (ratingOnPopups)
+						displayRating(event.rating, event);
 					ratingNum += 1;
 				}
 			}
@@ -1729,8 +1744,8 @@ class PlayState extends MusicBeatState
 
 		var separatedScore:String = Std.string(combo).addZeros(3);
 
-		if (combo == 0 || combo >= 10) {
-			if (combo >= 10) {
+		if (minDigitDisplay >= 0 && (combo == 0 || combo >= minDigitDisplay)) {
+			if (comboSpriteOnPopups) {
 				var comboSpr:FlxSprite = comboGroup.recycleLoop(FlxSprite).loadAnimatedGraphic(Paths.image('${pre}combo${suf}'));
 				comboSpr.resetSprite(comboGroup.x, comboGroup.y);
 				comboSpr.acceleration.y = 600;

--- a/source/funkin/game/PlayState.hx
+++ b/source/funkin/game/PlayState.hx
@@ -1661,9 +1661,9 @@ class PlayState extends MusicBeatState
 
 		var event:NoteHitEvent;
 		if (strumLine != null && !strumLine.cpu)
-			event = EventManager.get(NoteHitEvent).recycle(false, !note.isSustainNote, !note.isSustainNote, note, strumLine.characters, true, note.noteType, note.animSuffix.getDefault(note.strumID < strumLine.members.length ? strumLine.members[note.strumID].animSuffix : strumLine.animSuffix), "game/score/", "", note.strumID, score, note.isSustainNote ? null : accuracy, 0.023, daRating, Options.splashesEnabled && !note.isSustainNote && daRating == "sick");
-		else
-			event = EventManager.get(NoteHitEvent).recycle(false, false, false, note, strumLine.characters, false, note.noteType, note.animSuffix.getDefault(note.strumID < strumLine.members.length ? strumLine.members[note.strumID].animSuffix : strumLine.animSuffix), "game/score/", "", note.strumID, 0, null, 0, daRating, false);
+            event = EventManager.get(NoteHitEvent).recycle(false, !note.isSustainNote, !note.isSustainNote, null, defDisplayRating, defDisplayCombo, note, strumLine.characters, true, note.noteType, note.animSuffix.getDefault(note.strumID < strumLine.members.length ? strumLine.members[note.strumID].animSuffix : strumLine.animSuffix), "game/score/", "", note.strumID, score, note.isSustainNote ? null : accuracy, 0.023, daRating, Options.splashesEnabled && !note.isSustainNote && daRating == "sick");
+        else
+            event = EventManager.get(NoteHitEvent).recycle(false, false, false, null, defDisplayRating, defDisplayCombo, note, strumLine.characters, false, note.noteType, note.animSuffix.getDefault(note.strumID < strumLine.members.length ? strumLine.members[note.strumID].animSuffix : strumLine.animSuffix), "game/score/", "", note.strumID, 0, null, 0, daRating, false);
 		event.deleteNote = !note.isSustainNote; // work around, to allow sustain notes to be deleted
 		event = scripts.event(strumLine != null && !strumLine.cpu ? "onPlayerHit" : "onDadHit", event);
 		strumLine.onHit.dispatch(event);

--- a/source/funkin/game/PlayState.hx
+++ b/source/funkin/game/PlayState.hx
@@ -456,19 +456,21 @@ class PlayState extends MusicBeatState
 	 */
 	public var comboGroup:RotatingSpriteGroup;
 	/**
-	 * If the rating should be displayed when hitting notes.
+	 * Whenever the Rating sprites should be shown or not.
+	 *
+	 * NOTE: This is just a default value for the final value, the final value can be changed through notes hit events.
 	 */
-	public var ratingOnPopups:Bool = true;
+	public var defDisplayRating:Bool = true;
 	/**
-	 * Minimum Combo Count to display the combo digits.
-	 * anything less than 0 means it won't be shown
+	 * Whenever the Combo sprite should be shown or not (like old Week 7 patches).
+	 *
+	 * NOTE: This is just a default value for the final value, the final value can be changed through notes hit events.
+	 */
+	public var defDisplayCombo:Bool = false;
+	/**
+	 * Minimum Combo Count to display the combo digits. Anything less than 0 means it won't be shown.
 	 */
 	public var minDigitDisplay:Int = 10;
-	/**
-	 * If the image with "COMBO" written on it should be displayed (like old Week 7 patches)
-	 * PS: this shit's useless keep it off if you don't wanna clutter the UI
-	 */
-	public var comboSpriteOnPopups:Bool = false;
 	/**
 	 * Array containing all of the note types names.
 	 */
@@ -1680,8 +1682,10 @@ class PlayState extends MusicBeatState
 				if (event.showRating || (event.showRating == null && event.player))
 				{
 					displayCombo(event);
-					if (ratingOnPopups)
+
+					if (event.displayRating || (event.displayRating == null && defDisplayRating))
 						displayRating(event.rating, event);
+
 					ratingNum += 1;
 				}
 			}
@@ -1745,7 +1749,7 @@ class PlayState extends MusicBeatState
 		var separatedScore:String = Std.string(combo).addZeros(3);
 
 		if (minDigitDisplay >= 0 && (combo == 0 || combo >= minDigitDisplay)) {
-			if (comboSpriteOnPopups) {
+			if (evt.displayCombo || (evt.displayCombo == null && defDisplayCombo)) {
 				var comboSpr:FlxSprite = comboGroup.recycleLoop(FlxSprite).loadAnimatedGraphic(Paths.image('${pre}combo${suf}'));
 				comboSpr.resetSprite(comboGroup.x, comboGroup.y);
 				comboSpr.acceleration.y = 600;

--- a/source/funkin/game/PlayState.hx
+++ b/source/funkin/game/PlayState.hx
@@ -1661,9 +1661,9 @@ class PlayState extends MusicBeatState
 
 		var event:NoteHitEvent;
 		if (strumLine != null && !strumLine.cpu)
-            event = EventManager.get(NoteHitEvent).recycle(false, !note.isSustainNote, !note.isSustainNote, null, defDisplayRating, defDisplayCombo, note, strumLine.characters, true, note.noteType, note.animSuffix.getDefault(note.strumID < strumLine.members.length ? strumLine.members[note.strumID].animSuffix : strumLine.animSuffix), "game/score/", "", note.strumID, score, note.isSustainNote ? null : accuracy, 0.023, daRating, Options.splashesEnabled && !note.isSustainNote && daRating == "sick");
-        else
-            event = EventManager.get(NoteHitEvent).recycle(false, false, false, null, defDisplayRating, defDisplayCombo, note, strumLine.characters, false, note.noteType, note.animSuffix.getDefault(note.strumID < strumLine.members.length ? strumLine.members[note.strumID].animSuffix : strumLine.animSuffix), "game/score/", "", note.strumID, 0, null, 0, daRating, false);
+			event = EventManager.get(NoteHitEvent).recycle(false, !note.isSustainNote, !note.isSustainNote, null, defDisplayRating, defDisplayCombo, note, strumLine.characters, true, note.noteType, note.animSuffix.getDefault(note.strumID < strumLine.members.length ? strumLine.members[note.strumID].animSuffix : strumLine.animSuffix), "game/score/", "", note.strumID, score, note.isSustainNote ? null : accuracy, 0.023, daRating, Options.splashesEnabled && !note.isSustainNote && daRating == "sick");
+		else
+			event = EventManager.get(NoteHitEvent).recycle(false, false, false, null, defDisplayRating, defDisplayCombo, note, strumLine.characters, false, note.noteType, note.animSuffix.getDefault(note.strumID < strumLine.members.length ? strumLine.members[note.strumID].animSuffix : strumLine.animSuffix), "game/score/", "", note.strumID, 0, null, 0, daRating, false);
 		event.deleteNote = !note.isSustainNote; // work around, to allow sustain notes to be deleted
 		event = scripts.event(strumLine != null && !strumLine.cpu ? "onPlayerHit" : "onDadHit", event);
 		strumLine.onHit.dispatch(event);
@@ -1682,10 +1682,8 @@ class PlayState extends MusicBeatState
 				if (event.showRating || (event.showRating == null && event.player))
 				{
 					displayCombo(event);
-
-					if (event.displayRating || (event.displayRating == null && defDisplayRating))
+					if (event.displayRating)
 						displayRating(event.rating, event);
-
 					ratingNum += 1;
 				}
 			}
@@ -1749,7 +1747,7 @@ class PlayState extends MusicBeatState
 		var separatedScore:String = Std.string(combo).addZeros(3);
 
 		if (minDigitDisplay >= 0 && (combo == 0 || combo >= minDigitDisplay)) {
-			if (evt.displayCombo || (evt.displayCombo == null && defDisplayCombo)) {
+			if (evt.displayCombo) {
 				var comboSpr:FlxSprite = comboGroup.recycleLoop(FlxSprite).loadAnimatedGraphic(Paths.image('${pre}combo${suf}'));
 				comboSpr.resetSprite(comboGroup.x, comboGroup.y);
 				comboSpr.acceleration.y = 600;

--- a/source/funkin/game/PlayState.hx
+++ b/source/funkin/game/PlayState.hx
@@ -1741,10 +1741,10 @@ class PlayState extends MusicBeatState
 	}
 
 	public function displayCombo(?evt:NoteHitEvent = null):Void {
-		var pre:String = evt != null ? evt.ratingPrefix : "";
-		var suf:String = evt != null ? evt.ratingSuffix : "";
-
 		if (minDigitDisplay >= 0 && (combo == 0 || combo >= minDigitDisplay)) {
+			var pre:String = evt != null ? evt.ratingPrefix : "";
+			var suf:String = evt != null ? evt.ratingSuffix : "";
+
 			if (evt.displayCombo) {
 				var comboSpr:FlxSprite = comboGroup.recycleLoop(FlxSprite).loadAnimatedGraphic(Paths.image('${pre}combo${suf}'));
 				comboSpr.resetSprite(comboGroup.x, comboGroup.y);

--- a/source/funkin/game/PlayState.hx
+++ b/source/funkin/game/PlayState.hx
@@ -1744,8 +1744,6 @@ class PlayState extends MusicBeatState
 		var pre:String = evt != null ? evt.ratingPrefix : "";
 		var suf:String = evt != null ? evt.ratingSuffix : "";
 
-		var separatedScore:String = Std.string(combo).addZeros(3);
-
 		if (minDigitDisplay >= 0 && (combo == 0 || combo >= minDigitDisplay)) {
 			if (evt.displayCombo) {
 				var comboSpr:FlxSprite = comboGroup.recycleLoop(FlxSprite).loadAnimatedGraphic(Paths.image('${pre}combo${suf}'));
@@ -1769,6 +1767,7 @@ class PlayState extends MusicBeatState
 				});
 			}
 
+			var separatedScore:String = Std.string(combo).addZeros(3);
 			for (i in 0...separatedScore.length)
 			{
 				var numScore:FlxSprite = comboGroup.recycleLoop(FlxSprite).loadAnimatedGraphic(Paths.image('${pre}num${separatedScore.charAt(i)}${suf}'));


### PR DESCRIPTION
added new variables for users to decide if judgements and combo can pop up

`defDisplayRating`, `displayRating` -> displays the judgement you got from a note hit if toggled

`minDigitDisplay` -> how many notes should be hit in sequence for the combo numbers to show up, if this is negative, then it will never show up

`defDisplayCombo`, `displayCombo` -> displays the "COMBO" sprite if toggled