### PR TITLE
Fixed Window dark mode issue for Windows 10 users!

### DIFF
--- a/source/funkin/backend/system/Main.hx
+++ b/source/funkin/backend/system/Main.hx
@@ -156,6 +156,9 @@ class Main extends Sprite
 		FlxG.signals.postStateSwitch.add(onStateSwitchPost);
 
 		FlxG.mouse.useSystemCursor = true;
+		#if DARK_MODE_WINDOW
+		if(funkin.backend.utils.NativeAPI.hasVersion("10")) funkin.backend.utils.NativeAPI.redrawWindowHeader();
+		#end
 
 		ModsFolder.init();
 		#if MOD_SUPPORT

--- a/source/funkin/backend/system/Main.hx
+++ b/source/funkin/backend/system/Main.hx
@@ -157,7 +157,7 @@ class Main extends Sprite
 
 		FlxG.mouse.useSystemCursor = true;
 		#if DARK_MODE_WINDOW
-		if(funkin.backend.utils.NativeAPI.hasVersion("windows 10")) funkin.backend.utils.NativeAPI.redrawWindowHeader();
+		if(funkin.backend.utils.NativeAPI.hasVersion("Windows 10")) funkin.backend.utils.NativeAPI.redrawWindowHeader();
 		#end
 
 		ModsFolder.init();

--- a/source/funkin/backend/system/Main.hx
+++ b/source/funkin/backend/system/Main.hx
@@ -157,7 +157,7 @@ class Main extends Sprite
 
 		FlxG.mouse.useSystemCursor = true;
 		#if DARK_MODE_WINDOW
-		if(funkin.backend.utils.NativeAPI.hasVersion("10")) funkin.backend.utils.NativeAPI.redrawWindowHeader();
+		if(funkin.backend.utils.NativeAPI.hasVersion("windows 10")) funkin.backend.utils.NativeAPI.redrawWindowHeader();
 		#end
 
 		ModsFolder.init();

--- a/source/funkin/backend/utils/CoolUtil.hx
+++ b/source/funkin/backend/utils/CoolUtil.hx
@@ -163,10 +163,6 @@ class CoolUtil
 		return result;
 	}
 
-	public static inline function FlxColorToArray(color:FlxColor):Array<Int> {
-		return [FlxColor.fromInt(color.alpha), FlxColor.fromInt(color.red), FlxColor.fromInt(color.green), FlxColor.fromInt(color.blue)];
-	}
-
 	/**
 	 * Creates eventual missing folders to the specified `path`
 	 *

--- a/source/funkin/backend/utils/CoolUtil.hx
+++ b/source/funkin/backend/utils/CoolUtil.hx
@@ -163,6 +163,10 @@ class CoolUtil
 		return result;
 	}
 
+	public static inline function FlxColorToArray(color:FlxColor):Array<Int> {
+		return [FlxColor.fromInt(color.alpha), FlxColor.fromInt(color.red), FlxColor.fromInt(color.green), FlxColor.fromInt(color.blue)];
+	}
+
 	/**
 	 * Creates eventual missing folders to the specified `path`
 	 *

--- a/source/funkin/backend/utils/NativeAPI.hx
+++ b/source/funkin/backend/utils/NativeAPI.hx
@@ -9,7 +9,6 @@ import flixel.util.FlxColor;
  * Class for functions that talk to a lower level than haxe, such as message boxes, and more.
  * Some functions might not have effect on some platforms.
  */
-using StringTools;
 class NativeAPI {
 	@:dox(hide) public static function registerAudio() {
 		#if windows
@@ -95,34 +94,63 @@ class NativeAPI {
 	 */
 	public static function setDarkMode(title:String, enable:Bool) {
 		#if windows
+		if(title == null) title = lime.app.Application.current.window.title;
 		Windows.setDarkMode(title, enable);
 		#end
 	}
 
 	/**
-	 * Switch the window's color to any color. This is exclusive to windows 11 users, unfortunately.
-	 * NOTE: Setting the color to 0xFFFFFFFE will set the border back to it's original color (or white).
+	 * Switch the window's color to any color.
+	 *
+	 * WARNING: This is exclusive to windows 11 users, unfortunately.
+	 *
 	 * NOTE: Setting the color to 0x00000000 (FlxColor.TRANSPARENT) will set the border (must have setBorder on) invisible.
 	 */
-	public static function setWindowBorderColor(title:String, color:FlxColor, setHeader:Bool = true, setBorder:Bool = false) {
+	public static function setWindowBorderColor(title:String, color:FlxColor, setHeader:Bool = true, setBorder:Bool = true) {
 		#if windows
-		var finalColor:Array<Int> = funkin.backend.utils.CoolUtil.FlxColorToArray(color);
-		Windows.setWindowBorderColor(title, ((finalColor != null) ? finalColor : [0, 0, 0, 0]), setHeader, setBorder);
+		if(title == null) title = lime.app.Application.current.window.title;
+		Windows.setWindowBorderColor(title, [color.red, color.green, color.blue, color.alpha], setHeader, setBorder);
 		#end
 	}
 
 	/**
-	 * Switch the window's title text to any color. This is exclusive to windows 11 users too.
+	 * Resets the window's border color to the default one.
+	 *
+	 * WARNING: This is exclusive to windows 11 users, unfortunately.
+	**/
+	public static function resetWindowBorderColor(title:String, setHeader:Bool = true, setBorder:Bool = true) {
+		#if windows
+		if(title == null) title = lime.app.Application.current.window.title;
+		Windows.setWindowBorderColor(title, [-1, -1, -1, -1], setHeader, setBorder);
+		#end
+	}
+
+	/**
+	 * Switch the window's title text to any color.
+	 *
+	 * WARNING: This is exclusive to windows 11 users, unfortunately.
 	 */
 	public static function setWindowTitleColor(title:String, color:FlxColor) {
 		#if windows
-		var finalColor:Array<Int> = funkin.backend.utils.CoolUtil.FlxColorToArray(color);
-		Windows.setWindowTitleColor(title, ((finalColor != null) ? finalColor : [0, 0, 0, 0]));
+		if(title == null) title = lime.app.Application.current.window.title;
+		Windows.setWindowTitleColor(title, [color.red, color.green, color.blue, color.alpha]);
 		#end
 	}
 
 	/**
-	 * Forces the window header to redraw, fixing an issue for Windows 10 users.
+	 * Resets the window's title color to the default one.
+	 *
+	 * WARNING: This is exclusive to windows 11 users, unfortunately.
+	**/
+	public static function resetWindowTitleColor(title:String) {
+		#if windows
+		if(title == null) title = lime.app.Application.current.window.title;
+		Windows.setWindowTitleColor(title, [-1, -1, -1, -1]);
+		#end
+	}
+
+	/**
+	 * Forces the window header to redraw, causes a small visual jitter so use it sparingly.
 	 */
 	public static function redrawWindowHeader() {
 		#if windows
@@ -134,8 +162,8 @@ class NativeAPI {
 	/**
 	 * Can be used to check if your using a specific version of an OS (or if your using a certain OS).
 	 */
-	public static function hasVersion(vers:String = "10")
-		return lime.system.System.platformLabel.toLowerCase().contains(vers);
+	public static function hasVersion(vers:String)
+		return lime.system.System.platformLabel.toLowerCase().indexOf(vers.toLowerCase()) != -1;
 
 	/**
 	 * Shows a message box

--- a/source/funkin/backend/utils/NativeAPI.hx
+++ b/source/funkin/backend/utils/NativeAPI.hx
@@ -105,7 +105,7 @@ class NativeAPI {
 	public static function setWindowBorderColor(title:String, color:FlxColor, setHeader:Bool = true, setBorder:Bool = false) {
 		#if windows
 		var finalColor:Array<Int> = funkin.backend.utils.CoolUtil.FlxColorToArray(color);
-		Windows.setWindowBorderColor(title, ((finalColor != null) ? finalColor : [255, 255, 255]), setHeader, setBorder);
+		Windows.setWindowBorderColor(title, ((finalColor != null) ? finalColor : [0, 0, 0, 0]), setHeader, setBorder);
 		#end
 	}
 
@@ -115,7 +115,7 @@ class NativeAPI {
 	public static function setWindowTitleColor(title:String, color:FlxColor) {
 		#if windows
 		var finalColor:Array<Int> = funkin.backend.utils.CoolUtil.FlxColorToArray(color);
-		Windows.setWindowTitleColor(title, ((finalColor != null) ? finalColor : [255, 255, 255]));
+		Windows.setWindowTitleColor(title, ((finalColor != null) ? finalColor : [0, 0, 0, 0]));
 		#end
 	}
 

--- a/source/funkin/backend/utils/NativeAPI.hx
+++ b/source/funkin/backend/utils/NativeAPI.hx
@@ -84,11 +84,43 @@ class NativeAPI {
 		#end
 	}
 
+	/**
+	 * WINDOW COLOR MODE FUNCTIONS.
+	 */
+
+	/**
+	 * Switch the window's color mode to dark or light mode.
+	 */
 	public static function setDarkMode(title:String, enable:Bool) {
 		#if windows
 		Windows.setDarkMode(title, enable);
 		#end
 	}
+
+	/**
+	 * Switch the window's color to any color. This is exclusive to windows 11 users, unfortunately.
+	 */
+	public static function setWindowBorderColor(color:Array<Int>, setHeader:Bool = true, setBorder:Bool = false) {
+		#if windows
+		Windows.setWindowBorderColor(((color != null) ? color : [255, 255, 255]), setHeader, setBorder);
+		#end
+	}
+
+	/**
+	 * Forces the window header to redraw, fixing an issue for Windows 10 users.
+	 */
+	public static function redrawWindowHeader() {
+		#if windows
+		flixel.FlxG.stage.window.borderless = true;
+		flixel.FlxG.stage.window.borderless = false;
+		#end
+	}
+
+	/**
+	 * Can be used to check if your using a specific version of an OS (or if your using a certain OS).
+	 */
+	public static function hasVersion(vers:String = "10")
+		return lime.system.System.platformLabel.contains(vers);
 
 	/**
 	 * Shows a message box

--- a/source/funkin/backend/utils/NativeAPI.hx
+++ b/source/funkin/backend/utils/NativeAPI.hx
@@ -101,6 +101,8 @@ class NativeAPI {
 
 	/**
 	 * Switch the window's color to any color. This is exclusive to windows 11 users, unfortunately.
+	 * NOTE: Setting the color to 0xFFFFFFFE will set the border back to it's original color (or white).
+	 * NOTE: Setting the color to 0x00000000 (FlxColor.TRANSPARENT) will set the border (must have setBorder on) invisible.
 	 */
 	public static function setWindowBorderColor(title:String, color:FlxColor, setHeader:Bool = true, setBorder:Bool = false) {
 		#if windows

--- a/source/funkin/backend/utils/NativeAPI.hx
+++ b/source/funkin/backend/utils/NativeAPI.hx
@@ -100,9 +100,9 @@ class NativeAPI {
 	/**
 	 * Switch the window's color to any color. This is exclusive to windows 11 users, unfortunately.
 	 */
-	public static function setWindowBorderColor(color:Array<Int>, setHeader:Bool = true, setBorder:Bool = false) {
+	public static function setWindowBorderColor(title:String, color:Array<Int>, setHeader:Bool = true, setBorder:Bool = false) {
 		#if windows
-		Windows.setWindowBorderColor(((color != null) ? color : [255, 255, 255]), setHeader, setBorder);
+		Windows.setWindowBorderColor(title, ((color != null) ? color : [255, 255, 255]), setHeader, setBorder);
 		#end
 	}
 

--- a/source/funkin/backend/utils/NativeAPI.hx
+++ b/source/funkin/backend/utils/NativeAPI.hx
@@ -3,11 +3,13 @@ package funkin.backend.utils;
 import funkin.backend.utils.native.*;
 import flixel.util.typeLimit.OneOfTwo;
 import flixel.util.typeLimit.OneOfThree;
+import flixel.util.FlxColor;
 
 /**
  * Class for functions that talk to a lower level than haxe, such as message boxes, and more.
  * Some functions might not have effect on some platforms.
  */
+using StringTools;
 class NativeAPI {
 	@:dox(hide) public static function registerAudio() {
 		#if windows
@@ -100,9 +102,20 @@ class NativeAPI {
 	/**
 	 * Switch the window's color to any color. This is exclusive to windows 11 users, unfortunately.
 	 */
-	public static function setWindowBorderColor(title:String, color:Array<Int>, setHeader:Bool = true, setBorder:Bool = false) {
+	public static function setWindowBorderColor(title:String, color:FlxColor, setHeader:Bool = true, setBorder:Bool = false) {
 		#if windows
-		Windows.setWindowBorderColor(title, ((color != null) ? color : [255, 255, 255]), setHeader, setBorder);
+		var finalColor:Array<Int> = funkin.backend.utils.CoolUtil.FlxColorToArray(color);
+		Windows.setWindowBorderColor(title, ((finalColor != null) ? finalColor : [255, 255, 255]), setHeader, setBorder);
+		#end
+	}
+
+	/**
+	 * Switch the window's title text to any color. This is exclusive to windows 11 users too.
+	 */
+	public static function setWindowTitleColor(title:String, color:FlxColor) {
+		#if windows
+		var finalColor:Array<Int> = funkin.backend.utils.CoolUtil.FlxColorToArray(color);
+		Windows.setWindowTitleColor(title, ((finalColor != null) ? finalColor : [255, 255, 255]));
 		#end
 	}
 
@@ -120,7 +133,7 @@ class NativeAPI {
 	 * Can be used to check if your using a specific version of an OS (or if your using a certain OS).
 	 */
 	public static function hasVersion(vers:String = "10")
-		return lime.system.System.platformLabel.contains(vers);
+		return lime.system.System.platformLabel.toLowerCase().contains(vers);
 
 	/**
 	 * Shows a message box

--- a/source/funkin/backend/utils/native/Windows.hx
+++ b/source/funkin/backend/utils/native/Windows.hx
@@ -134,9 +134,14 @@ class Windows {
 		HWND window = FindWindowA(NULL, title.c_str());
 		// Look for child windows if top level aint found
 		if (window == NULL) window = FindWindowExA(GetActiveWindow(), NULL, NULL, title.c_str());
+		// If still not found, try to get the active window
+		if (window == NULL) window = GetActiveWindow();
 
-		if (window != NULL && S_OK != DwmSetWindowAttribute(window, 19, &darkMode, sizeof(darkMode))) {
-			DwmSetWindowAttribute(window, 20, &darkMode, sizeof(darkMode));
+		if (window != NULL) {
+			if (S_OK != DwmSetWindowAttribute(window, 19, &darkMode, sizeof(darkMode))) {
+				DwmSetWindowAttribute(window, 20, &darkMode, sizeof(darkMode));
+			}
+			UpdateWindow(window);
 		}
 	')
 	public static function setDarkMode(title:String, enable:Bool) {}
@@ -144,31 +149,42 @@ class Windows {
 	@:functionCode('
 	HWND window = FindWindowA(NULL, title.c_str());
 	if (window == NULL) window = FindWindowExA(GetActiveWindow(), NULL, NULL, title.c_str());
+	if (window == NULL) window = GetActiveWindow();
 
-	auto finalColor = NULL; //Make it null so we do not get an error for not initializing an auto.
-	if(color[0] == 255 && color[1] == 255 && color[2] == 255 && color[3] == 254) { //bad fix, I know :sob:
-		finalColor = 0xFFFFFFFF; //Default border
-	} else if(color[0] == 0) {
-		finalColor = 0xFFFFFFFE; //No border (must have setBorder as true)
+	COLORREF finalColor;
+	if(color[0] == -1 && color[1] == -1 && color[2] == -1 && color[3] == -1) { // bad fix, I know :sob:
+		finalColor = 0xFFFFFFFF; // Default border
+	} else if(color[3] == 0) {
+		finalColor = 0xFFFFFFFE; // No border (must have setBorder as true)
 	} else {
-		finalColor = RGB(color[1], color[2], color[3]); //Use your custom color	
+		finalColor = RGB(color[0], color[1], color[2]); // Use your custom color
 	}
 
-	if(setHeader) DwmSetWindowAttribute(window, 35, &finalColor, sizeof(COLORREF));
-	if(setBorder) DwmSetWindowAttribute(window, 34, &finalColor, sizeof(COLORREF));
+	if (window != NULL) {
+		if(setHeader) DwmSetWindowAttribute(window, 35, &finalColor, sizeof(COLORREF));
+		if(setBorder) DwmSetWindowAttribute(window, 34, &finalColor, sizeof(COLORREF));
 
-	UpdateWindow(window);
+		UpdateWindow(window);
+	}
 	')
-	public static function setWindowBorderColor(title:String, color:Array<Int>, setHeader:Bool = true, setBorder:Bool = false) {}
+	public static function setWindowBorderColor(title:String, color:Array<Int>, setHeader:Bool = true, setBorder:Bool = true) {}
 
 	@:functionCode('
 	HWND window = FindWindowA(NULL, title.c_str());
 	if (window == NULL) window = FindWindowExA(GetActiveWindow(), NULL, NULL, title.c_str());
+	if (window == NULL) window = GetActiveWindow();
 
-	auto finalColor = RGB(color[1], color[2], color[3]);	
+	COLORREF finalColor;
+	if(color[0] == -1 && color[1] == -1 && color[2] == -1 && color[3] == -1) { // bad fix, I know :sob:
+		finalColor = 0xFFFFFFFF; // Default border
+	} else {
+		finalColor = RGB(color[0], color[1], color[2]); // Use your custom color
+	}
 
-	DwmSetWindowAttribute(window, 36, &finalColor, sizeof(COLORREF));
-	UpdateWindow(window);
+	if (window != NULL) {
+		DwmSetWindowAttribute(window, 36, &finalColor, sizeof(COLORREF));
+		UpdateWindow(window);
+	}
 	')
 	public static function setWindowTitleColor(title:String, color:Array<Int>) {}
 

--- a/source/funkin/backend/utils/native/Windows.hx
+++ b/source/funkin/backend/utils/native/Windows.hx
@@ -146,7 +146,7 @@ class Windows {
 	if (window == NULL) window = FindWindowExA(GetActiveWindow(), NULL, NULL, title.c_str());
 
 	auto finalColor = NULL; //Make it null so we do not get an error for not initializing an auto.
-	if(color == NULL) finalColor = 0xFFFFFFFF; //Default border
+	if(color == [255, 255, 255, 254]) finalColor = 0xFFFFFFFF; //Default border
 	else if(color[0] == 0) finalColor = 0xFFFFFFFE; //No border
 	else finalColor = RGB(color[1], color[2], color[3]); //Use your custom color	
 			

--- a/source/funkin/backend/utils/native/Windows.hx
+++ b/source/funkin/backend/utils/native/Windows.hx
@@ -136,13 +136,12 @@ class Windows {
 		if (window == NULL) window = FindWindowExA(GetActiveWindow(), NULL, NULL, title.c_str());
 		// If still not found, try to get the active window
 		if (window == NULL) window = GetActiveWindow();
+		if (window == NULL) return;
 
-		if (window != NULL) {
-			if (S_OK != DwmSetWindowAttribute(window, 19, &darkMode, sizeof(darkMode))) {
-				DwmSetWindowAttribute(window, 20, &darkMode, sizeof(darkMode));
-			}
-			UpdateWindow(window);
+		if (S_OK != DwmSetWindowAttribute(window, 19, &darkMode, sizeof(darkMode))) {
+			DwmSetWindowAttribute(window, 20, &darkMode, sizeof(darkMode));
 		}
+		UpdateWindow(window);
 	')
 	public static function setDarkMode(title:String, enable:Bool) {}
 

--- a/source/funkin/backend/utils/native/Windows.hx
+++ b/source/funkin/backend/utils/native/Windows.hx
@@ -142,19 +142,6 @@ class Windows {
 	public static function setDarkMode(title:String, enable:Bool) {}
 
 	@:functionCode('
-		int darkMode = enable ? 1 : 0;
-
-		HWND window = FindWindowA(NULL, title.c_str());
-		// Look for child windows if top level aint found
-		if (window == NULL) window = FindWindowExA(GetActiveWindow(), NULL, NULL, title.c_str());
-
-		if (window != NULL && S_OK != DwmSetWindowAttribute(window, 19, &darkMode, sizeof(darkMode))) {
-			DwmSetWindowAttribute(window, 20, &darkMode, sizeof(darkMode));
-		}
-	')
-	public static function setDarkMode(title:String, color:Array<Int>) {}
-
-	@:functionCode('
 	HWND window = FindWindowA(NULL, title.c_str());
 	if (window == NULL) window = FindWindowExA(GetActiveWindow(), NULL, NULL, title.c_str());
 
@@ -166,6 +153,16 @@ class Windows {
 	UpdateWindow(window);
 	')
 	public static function setWindowBorderColor(title:String, color:Array<Int>, setHeader:Bool = true, setBorder:Bool = false) {}
+
+	@:functionCode('
+	HWND window = FindWindowA(NULL, title.c_str());
+	if (window == NULL) window = FindWindowExA(GetActiveWindow(), NULL, NULL, title.c_str());
+
+	auto finalColor = RGB(color[0], color[1], color[2]);	
+	DwmSetWindowAttribute(window, 36, &finalColor, sizeof(COLORREF));
+	UpdateWindow(window);
+	')
+	public static function setWindowTitleColor(title:String, color:Array<Int>) {}
 
 	@:functionCode('
 	// https://stackoverflow.com/questions/15543571/allocconsole-not-displaying-cout

--- a/source/funkin/backend/utils/native/Windows.hx
+++ b/source/funkin/backend/utils/native/Windows.hx
@@ -150,6 +150,7 @@ class Windows {
 	HWND window = FindWindowA(NULL, title.c_str());
 	if (window == NULL) window = FindWindowExA(GetActiveWindow(), NULL, NULL, title.c_str());
 	if (window == NULL) window = GetActiveWindow();
+	if (window == NULL) return;
 
 	COLORREF finalColor;
 	if(color[0] == -1 && color[1] == -1 && color[2] == -1 && color[3] == -1) { // bad fix, I know :sob:
@@ -160,12 +161,10 @@ class Windows {
 		finalColor = RGB(color[0], color[1], color[2]); // Use your custom color
 	}
 
-	if (window != NULL) {
-		if(setHeader) DwmSetWindowAttribute(window, 35, &finalColor, sizeof(COLORREF));
-		if(setBorder) DwmSetWindowAttribute(window, 34, &finalColor, sizeof(COLORREF));
+	if(setHeader) DwmSetWindowAttribute(window, 35, &finalColor, sizeof(COLORREF));
+	if(setBorder) DwmSetWindowAttribute(window, 34, &finalColor, sizeof(COLORREF));
 
-		UpdateWindow(window);
-	}
+	UpdateWindow(window);
 	')
 	public static function setWindowBorderColor(title:String, color:Array<Int>, setHeader:Bool = true, setBorder:Bool = true) {}
 
@@ -173,6 +172,7 @@ class Windows {
 	HWND window = FindWindowA(NULL, title.c_str());
 	if (window == NULL) window = FindWindowExA(GetActiveWindow(), NULL, NULL, title.c_str());
 	if (window == NULL) window = GetActiveWindow();
+	if (window == NULL) return;
 
 	COLORREF finalColor;
 	if(color[0] == -1 && color[1] == -1 && color[2] == -1 && color[3] == -1) { // bad fix, I know :sob:
@@ -181,10 +181,8 @@ class Windows {
 		finalColor = RGB(color[0], color[1], color[2]); // Use your custom color
 	}
 
-	if (window != NULL) {
-		DwmSetWindowAttribute(window, 36, &finalColor, sizeof(COLORREF));
-		UpdateWindow(window);
-	}
+	DwmSetWindowAttribute(window, 36, &finalColor, sizeof(COLORREF));
+	UpdateWindow(window);
 	')
 	public static function setWindowTitleColor(title:String, color:Array<Int>) {}
 

--- a/source/funkin/backend/utils/native/Windows.hx
+++ b/source/funkin/backend/utils/native/Windows.hx
@@ -142,6 +142,32 @@ class Windows {
 	public static function setDarkMode(title:String, enable:Bool) {}
 
 	@:functionCode('
+		int darkMode = enable ? 1 : 0;
+
+		HWND window = FindWindowA(NULL, title.c_str());
+		// Look for child windows if top level aint found
+		if (window == NULL) window = FindWindowExA(GetActiveWindow(), NULL, NULL, title.c_str());
+
+		if (window != NULL && S_OK != DwmSetWindowAttribute(window, 19, &darkMode, sizeof(darkMode))) {
+			DwmSetWindowAttribute(window, 20, &darkMode, sizeof(darkMode));
+		}
+	')
+	public static function setDarkMode(title:String, color:Array<Int>) {}
+
+	@:functionCode('
+	HWND window = FindWindowA(NULL, title.c_str());
+	if (window == NULL) window = FindWindowExA(GetActiveWindow(), NULL, NULL, title.c_str());
+
+	auto finalColor = RGB(color[0], color[1], color[2]);
+			
+	if(setHeader) DwmSetWindowAttribute(window, 35, &finalColor, sizeof(COLORREF));
+	if(setBorder) DwmSetWindowAttribute(window, 34, &finalColor, sizeof(COLORREF));
+			
+	UpdateWindow(window);
+	')
+	public static function setWindowBorderColor(title:String, color:Array<Int>, setHeader:Bool = true, setBorder:Bool = false) {}
+
+	@:functionCode('
 	// https://stackoverflow.com/questions/15543571/allocconsole-not-displaying-cout
 
 	if (!AllocConsole())

--- a/source/funkin/backend/utils/native/Windows.hx
+++ b/source/funkin/backend/utils/native/Windows.hx
@@ -145,7 +145,7 @@ class Windows {
 	HWND window = FindWindowA(NULL, title.c_str());
 	if (window == NULL) window = FindWindowExA(GetActiveWindow(), NULL, NULL, title.c_str());
 
-	auto finalColor = NULL; //Make it null so we don't get an error for not initializing an auto.
+	auto finalColor = NULL; //Make it null so we do not get an error for not initializing an auto.
 	if(color == NULL) finalColor = 0xFFFFFFFF; //Default border
 	else if(color[0] == 0) finalColor = 0xFFFFFFFE; //No border
 	else finalColor = RGB(color[1], color[2], color[3]); //Use your custom color	

--- a/source/funkin/backend/utils/native/Windows.hx
+++ b/source/funkin/backend/utils/native/Windows.hx
@@ -146,13 +146,17 @@ class Windows {
 	if (window == NULL) window = FindWindowExA(GetActiveWindow(), NULL, NULL, title.c_str());
 
 	auto finalColor = NULL; //Make it null so we do not get an error for not initializing an auto.
-	if(color == [255, 255, 255, 254]) finalColor = 0xFFFFFFFF; //Default border
-	else if(color[0] == 0) finalColor = 0xFFFFFFFE; //No border
-	else finalColor = RGB(color[1], color[2], color[3]); //Use your custom color	
-			
+	if(color[0] == 255 && color[1] == 255 && color[2] == 255 && color[3] == 254) { //bad fix, I know :sob:
+		finalColor = 0xFFFFFFFF; //Default border
+	} else if(color[0] == 0) {
+		finalColor = 0xFFFFFFFE; //No border (must have setBorder as true)
+	} else {
+		finalColor = RGB(color[1], color[2], color[3]); //Use your custom color	
+	}
+
 	if(setHeader) DwmSetWindowAttribute(window, 35, &finalColor, sizeof(COLORREF));
 	if(setBorder) DwmSetWindowAttribute(window, 34, &finalColor, sizeof(COLORREF));
-			
+
 	UpdateWindow(window);
 	')
 	public static function setWindowBorderColor(title:String, color:Array<Int>, setHeader:Bool = true, setBorder:Bool = false) {}

--- a/source/funkin/backend/utils/native/Windows.hx
+++ b/source/funkin/backend/utils/native/Windows.hx
@@ -145,7 +145,10 @@ class Windows {
 	HWND window = FindWindowA(NULL, title.c_str());
 	if (window == NULL) window = FindWindowExA(GetActiveWindow(), NULL, NULL, title.c_str());
 
-	auto finalColor = RGB(color[0], color[1], color[2]);
+	auto finalColor = NULL; //Make it null so we don't get an error for not initializing an auto.
+	if(color == NULL) finalColor = 0xFFFFFFFF; //Default border
+	else if(color[0] == 0) finalColor = 0xFFFFFFFE; //No border
+	else finalColor = RGB(color[1], color[2], color[3]); //Use your custom color	
 			
 	if(setHeader) DwmSetWindowAttribute(window, 35, &finalColor, sizeof(COLORREF));
 	if(setBorder) DwmSetWindowAttribute(window, 34, &finalColor, sizeof(COLORREF));
@@ -158,7 +161,8 @@ class Windows {
 	HWND window = FindWindowA(NULL, title.c_str());
 	if (window == NULL) window = FindWindowExA(GetActiveWindow(), NULL, NULL, title.c_str());
 
-	auto finalColor = RGB(color[0], color[1], color[2]);	
+	auto finalColor = RGB(color[1], color[2], color[3]);	
+
 	DwmSetWindowAttribute(window, 36, &finalColor, sizeof(COLORREF));
 	UpdateWindow(window);
 	')


### PR DESCRIPTION
-Added a fix for Windows 10 users where they would have to unfocus and refocus the application to set the window to dark mode.
-Added `setWindowBorderColor`, which can set the window header (and/or border) to any color.
  (NOTE: making your FlxColor have an alpha of 0 will make the window have no border. If your FlxColor is null, then it will use the default colors your system has set).
-Added `setWindowTitleColor`, which can set the window title to any color.