### PR TITLE
[BUGFIX] use `haxelib run lime` for compiling in commandline

### DIFF
--- a/commandline/commands/Compiler.hx
+++ b/commandline/commands/Compiler.hx
@@ -17,7 +17,10 @@ class Compiler {
 	private static function __build(args:Array<String>, arg:Array<String>) {
 		for(a in args)
 			arg.push(a);
-		Sys.command("lime", arg);
+
+		arg = ['run', 'lime'].concat(arg);
+
+		Sys.command("haxelib", arg);
 	}
 
 	public static function getBuildTarget() {


### PR DESCRIPTION
## What does this PR do?
Before, `commandline` would work by using whichever `lime` was used in `haxelib run lime setup`. This though, could cause some compatibility issues in the long run.

This PR makes it so `commandline` will now force people to use the `cne setup` (aka `hmm`) version of lime for commands, so these issues will never occur.


you might've been using a different version of lime for compiling
you just didn't know it yet!