### PR TITLE
(breaking?) tweak zoomFactor to use camera scrolling

### DIFF
--- a/source/funkin/backend/FunkinSprite.hx
+++ b/source/funkin/backend/FunkinSprite.hx
@@ -175,10 +175,13 @@ class FunkinSprite extends FlxSkewedSprite implements IBeatReceiver implements I
 	{
 		super.doAdditionalMatrixStuff(matrix, camera);
 		matrix.translate(-camera.width / 2, -camera.height / 2);
+		matrix.translate(-camera.scroll.x * scrollFactor.x, -camera.scroll.y * scrollFactor.y);
 
 		var requestedZoom = FlxMath.lerp(1, camera.zoom, zoomFactor);
 		var diff = requestedZoom / camera.zoom;
 		matrix.scale(diff, diff);
+
+		matrix.translate(camera.scroll.x * scrollFactor.x, camera.scroll.y * scrollFactor.y);
 		matrix.translate(camera.width / 2, camera.height / 2);
 	}
 


### PR DESCRIPTION
the zooming effect on sprites with their zoomFactor changed looked awkward because it wasnt taking camera scroll into account

yes this Will change visuals in all mods that use this property . maybe there should be a var to revert to old behavior or smth