### PR TITLE
Update macOS version to 14.

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     name: Mac OS Build
     permissions: write-all
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - name: Pulling the new commit
         uses: actions/checkout@v2


### PR DESCRIPTION
Reason: macOS 13 will be removed on 4th December in Github.