### PR TITLE
Fix events file not being removed when all global events are deleted

### DIFF
--- a/source/funkin/backend/chart/Chart.hx
+++ b/source/funkin/backend/chart/Chart.hx
@@ -300,6 +300,7 @@ class Chart {
 			var eventsPath = '$songPath/events$variantSuffix.json', events = filterEventsForSaving(chart.events, false, true);
 
 			if (events.length != 0) CoolUtil.safeSaveFile(eventsPath, Json.stringify({events: events}, null, prettyPrint));
+			else if (FileSystem.exists(eventsPath)) FileSystem.deleteFile(eventsPath); // If there's no events to save, then get rid of the file (if it exists already).
 		}
 		#end
 


### PR DESCRIPTION
A simple fix that simply deletes the `events.json` file if there's no global events to save, preventing them from coming back when reopening a chart. Friday Night Funkin'