### PR TITLE
Ensure ghost is removed before deleting animation in character editor

### DIFF
--- a/source/funkin/editors/character/CharacterAnimsWindow.hx
+++ b/source/funkin/editors/character/CharacterAnimsWindow.hx
@@ -104,6 +104,7 @@ class CharacterAnimsWindow extends UIButtonList<CharacterAnimButton> {
 		if (character.getAnimName() == button.anim)
 			@:privateAccess CharacterEditor.instance._animation_down(null);
 
+		character.ghosts.remove(button.anim);
 		character.removeAnimation(button.anim);
 		if (character.animOffsets.exists(button.anim)) character.animOffsets.remove(button.anim);
 		if (character.animDatas.exists(button.anim)) character.animDatas.remove(button.anim);


### PR DESCRIPTION
This fixes the null object reference error described at #819 by ensuring the animation is removed from the `ghosts` array prior to being deleted. Friday Night Funkin'