### PR TITLE
Save total of each rating to unused hits parameter in SongScore

### DIFF
--- a/source/funkin/game/PlayState.hx
+++ b/source/funkin/game/PlayState.hx
@@ -689,6 +689,8 @@ class PlayState extends MusicBeatState
 
 		detailsText = isStoryMode ? ("Story Mode: " + storyWeek.name) : "Freeplay";
 
+		for (rating in [for (i in ratingManager.ratingData) i.name]) hits.set(rating, 0); // Ensure all keys exist as to prevent null errors.
+
 		// Checks if cutscene files exists
 		var cutscenePath = Paths.script('songs/${SONG.meta.name}/cutscene');
 		var endCutscenePath = Paths.script('songs/${SONG.meta.name}/cutscene-end');


### PR DESCRIPTION
Saves how many of each rating has been received throughout the song/week to the currently unused `hits` parameter in `SongScore`. Codename Engine