### PR TITLE
Update macOS runner version to 15-intel

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     name: Mac OS Build
     permissions: write-all
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps:
       - name: Pulling the new commit
         uses: actions/checkout@v4


### PR DESCRIPTION
This is the only intel-based of macOS is free, since macOS 14 large is only for money, even though 15 is kinda slow, but works anyways.
Btw it's only available until 2027.