### PR TITLE
attempt to fix hold note positions by changing the values in strum.hx

### DIFF
--- a/source/funkin/game/Strum.hx
+++ b/source/funkin/game/Strum.hx
@@ -121,7 +121,7 @@ class Strum extends FlxSprite {
 	public override function update(elapsed:Float) {
 		super.update(elapsed);
 		if (cpu) {
-			if (lastHit + (Conductor.crochet / 2) < Conductor.songPosition && getAnim() == "confirm") {
+			if (lastHit + (Conductor.crochet * 0.5) < Conductor.songPosition && getAnim() == "confirm") {
 				playAnim("static");
 			}
 		}
@@ -133,7 +133,7 @@ class Strum extends FlxSprite {
 	}
 
 	@:noCompletion public static inline final PIX180:Float = 565.4866776461628; // 180 * Math.PI
-	@:noCompletion public static final N_WIDTHDIV2:Float = Note.swagWidth / 2;
+	@:noCompletion public static final N_WIDTHDIV2:Float = Note.swagWidth / 2; // DEPRECATED
 
 	/**
 	 * Updates the position of a note.
@@ -162,7 +162,7 @@ class Strum extends FlxSprite {
 
 		if (shouldX || shouldY) {
 			if (daNote.strumRelativePos) {
-				if (shouldX) daNote.x = (this.width - daNote.width) / 2;
+				if (shouldX) daNote.x = (this.width - daNote.width) * 0.5;
 				if (shouldY) {
 					daNote.y = (daNote.strumTime - Conductor.songPosition) * (0.45 * CoolUtil.quantize(getScrollSpeed(daNote), 100));
 					if (daNote.isSustainNote) daNote.y += height * 0.5;


### PR DESCRIPTION
I have noticed that when scaling strums (scale.y), the Hold Notes dont take that into account.

I have made  a PR that hopefully fixes this..

Heres a Showcase

Codename 1.0.1 (Before the patch): 

https://github.com/user-attachments/assets/2dd3c52d-024c-4c57-9c44-7643c274c810


CodenameFixes/clip-fix: (My Pull Request):

https://github.com/user-attachments/assets/4273bfef-ace7-41d0-8828-bc5c6302e458

and yes this works with pixel notes aswell

<img width="599" height="637" alt="image" src="https://github.com/user-attachments/assets/17eacb0e-23cf-41ae-900e-8129159989d0" />


