### PR TITLE
Use 'arch -x86_64' to force-compile on macOS 14/15

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     name: Mac OS Build
     permissions: write-all
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - name: Pulling the new commit
         uses: actions/checkout@v4
@@ -31,7 +31,7 @@ jobs:
           haxe -cp commandline -D analyzer-optimize --run Main setup -s
       - name: Building the game
         run: |
-          haxelib run lime build mac
+          arch -x86_64 haxelib run lime build mac
       - name: Tar files
         run: tar -zcvf CodenameEngine.tar.gz -C export/release/macos/bin .
       - name: Uploading artifact (executable)


### PR DESCRIPTION
I have appended the build command line with 'arch -x86_64', tested it on my fork and it finally works, but it's very slow to compile, which is kinda unfortunate, it took like an hour and over a half to build the macOS build for cne. Ig this is the only solution to fix this.