### PR TITLE
UTF-8

### DIFF
--- a/source/funkin/backend/utils/native/Windows.hx
+++ b/source/funkin/backend/utils/native/Windows.hx
@@ -204,6 +204,9 @@ final class Windows {
 	freopen("CONIN$", "r", stdin);
 	freopen("CONOUT$", "w", stdout);
 	freopen("CONOUT$", "w", stderr);
+
+	SetConsoleOutputCP(65001);
+	SetConsoleCP(65001);
 	')
 	public static function allocConsole() {
 	}


### PR DESCRIPTION
Fixed an issue where special characters would display incorrectly in the CMD window on Windows.
![CodenameEngine_yycCdJ2leq](https://github.com/user-attachments/assets/c3dec611-48cc-4252-ba47-da1218a7baee)