### PR TITLE
Add a way of "cancelling" updateSustainClip

### DIFF
--- a/source/funkin/backend/scripting/events/note/NoteHitEvent.hx
+++ b/source/funkin/backend/scripting/events/note/NoteHitEvent.hx
@@ -11,6 +11,7 @@ final class NoteHitEvent extends CancellableEvent {
 	@:dox(hide) public var unmuteVocals:Bool = true;
 	@:dox(hide) public var enableCamZooming:Bool = true;
 	@:dox(hide) public var autoHitLastSustain:Bool = true;
+	@:dox(hide) public var clipSustain:Bool = true;
 
 	/**
 	 * Whenever a miss should be added.
@@ -143,6 +144,13 @@ final class NoteHitEvent extends CancellableEvent {
 	**/
 	public function forceDeletion() {
 		deleteNote = true;
+	}
+
+	/**
+	 * Prevents the sustain from being cut. Only works if the note is a sustain.
+	 */
+	public function preventSustainClip() {
+		clipSustain = false;
 	}
 
 	/**

--- a/source/funkin/game/Note.hx
+++ b/source/funkin/game/Note.hx
@@ -83,6 +83,7 @@ class Note extends FlxSprite
 
 	public var sustainLength:Float = 0;
 	public var isSustainNote:Bool = false;
+	public var noSustainClip:Bool = false;
 	public var flipSustain:Bool = true;
 
 	public var noteTypeID:Int = 0;
@@ -222,6 +223,7 @@ class Note extends FlxSprite
 	public var lastScrollSpeed:Null<Float> = null;
 	public var gapFix:SingleOrFloat = 0;
 	public var useAntialiasingFix(get, set):Bool;
+
 	inline function set_useAntialiasingFix(v:Bool) {
 		if(v != useAntialiasingFix) {
 			gapFix = v ? 1 : 0;
@@ -308,7 +310,7 @@ class Note extends FlxSprite
 		updateSustainClip();
 	}
 
-	public function updateSustainClip() if (wasGoodHit) {
+	public function updateSustainClip() if (wasGoodHit && !noSustainClip) {
 		var t = FlxMath.bound((Conductor.songPosition - strumTime) / height * 0.45 * lastScrollSpeed, 0, 1);
 		var rect = clipRect == null ? FlxRect.get() : clipRect;
 		clipRect = rect.set(0, frameHeight * t, frameWidth, frameHeight * (1 - t));

--- a/source/funkin/game/PlayState.hx
+++ b/source/funkin/game/PlayState.hx
@@ -1952,6 +1952,8 @@ class PlayState extends MusicBeatState
 		strumLine.onHit.dispatch(event);
 		gameAndCharsEvent("onNoteHit", event);
 
+		note.noSustainClip = !event.clipSustain;
+		
 		if (!event.cancelled) {
 			if (!note.isSustainNote) {
 				if (event.countScore) songScore += event.score;

--- a/source/funkin/game/StrumLine.hx
+++ b/source/funkin/game/StrumLine.hx
@@ -224,9 +224,10 @@ class StrumLine extends FlxTypedGroup<Strum> {
 				daNote.tooLate = true;
 		}
 
-		if (cpu && __updateNote_event.__autoCPUHit && !daNote.avoid && !daNote.wasGoodHit && daNote.strumTime < __updateNote_songPos) PlayState.instance.goodNoteHit(this, daNote);
+		if (cpu && __updateNote_event.__autoCPUHit && !daNote.avoid && !daNote.wasGoodHit && daNote.strumTime < __updateNote_songPos)
+			PlayState.instance.goodNoteHit(this, daNote);
 
-		if (daNote.wasGoodHit && daNote.isSustainNote && daNote.strumTime + daNote.sustainLength < __updateNote_songPos) {
+		if (daNote.wasGoodHit && daNote.isSustainNote && daNote.strumTime + daNote.sustainLength < __updateNote_songPos && !daNote.noSustainClip) {
 			deleteNote(daNote);
 			return;
 		}


### PR DESCRIPTION
just as the title says, with this you can cancel the sustain's clipRect from updating in a NoteHitEvent using preventSustainClip.

i thought this was always a thing but apparently not from what i checked?

not the best but it'll work