### PR TITLE
More accurate compilation error reports

### DIFF
--- a/project.xml
+++ b/project.xml
@@ -188,7 +188,8 @@
 	<haxedef name="SOFTCODED_CLASSES" if="SOFTCODED_CLASSES" />
 	<haxedef name="USE_ADAPTED_ASSETS" if="USE_ADAPTED_ASSETS" />
 	<haxedef name="openfl_dpi_aware" if="openfl_dpi_aware" />
-	
+
+	<!-- Disable it for more concise compilation errors. -->
 	<haxedef name="message.reporting" value="pretty" />
 
 	<!-- _________________________________ Custom _______________________________ -->


### PR DESCRIPTION
Yes, it's specifically designed to provide more precise error messages during compilation, excluding HScript.
![GameViewerServer_TVubRemFUm](https://github.com/user-attachments/assets/f8f56ed5-3da2-4048-9fc9-8f56111956ab)
