### PR TITLE
optimize updateInput

### DIFF
--- a/source/funkin/game/StrumLine.hx
+++ b/source/funkin/game/StrumLine.hx
@@ -253,7 +253,7 @@ class StrumLine extends FlxTypedGroup<Strum> {
 	var __notePerStrum:Array<Note> = [];
 
 	function __inputProcessPressed(note:Note) {
-		if (__pressed[note.strumID] && note.isSustainNote && note.sustainParent.wasGoodHit && note.strumTime < __updateNote_songPos && !note.wasGoodHit) {
+		if (__pressed[note.strumID] && note.isSustainNote && note.strumTime < __updateNote_songPos && !note.wasGoodHit && note.sustainParent.wasGoodHit) {
 			PlayState.instance.goodNoteHit(this, note);
 		}
 	}


### PR DESCRIPTION
**Move the `justPressed` check into `pressed` to reduce performance overhead. `updatePlayerInput` no longer rechecks states.**

Checking states in the C++ code was a relatively heavy operation (about 115 lines), but now it's down to just one line.