### PR TITLE
Re-implement onDraw functionality for FunkinSprite

### DIFF
--- a/source/funkin/backend/FunkinSprite.hx
+++ b/source/funkin/backend/FunkinSprite.hx
@@ -173,6 +173,17 @@ class FunkinSprite extends FlxAnimate implements IBeatReceiver implements IOffse
 	{
 	}
 
+	public override function draw() {
+		// re-implementing the `onDraw` functionality from `FlxSprite` since `FlxAnimate` didn't have this, so we have to add it back in ourselves
+	    if (this.isAnimate && this.__drawOverrided) {
+	        this.__drawOverrided = false;
+	        this.onDraw(this);
+	        this.__drawOverrided = true;
+			return;
+	    }
+	    super.draw();
+	}
+
 	// ANIMATE ATLAS DRAWING
 	#if REGION
 


### PR DESCRIPTION
As FlxAnimate didn't have the functionality before, so we have to do the check in FunkinSprite ourselves, as it itself stop's calling the `super.draw();` when it is a `isAnimate`