### PR TITLE
SUSTAINS_AS_ONE_NOTE = MOD_API_VERSION < 2

### DIFF
--- a/source/funkin/backend/system/Flags.hx
+++ b/source/funkin/backend/system/Flags.hx
@@ -309,7 +309,7 @@ class Flags {
 		if (WINDOW_TITLE_USE_MOD_NAME == null) WINDOW_TITLE_USE_MOD_NAME = !overridenFlags.exists('TITLE') && overridenFlags.exists('MOD_NAME');
 		if (USE_LEGACY_TIMING == null) USE_LEGACY_TIMING = MOD_API_VERSION < 2;
 		if (USE_LEGACY_ZOOM_FACTOR == null) USE_LEGACY_ZOOM_FACTOR = MOD_API_VERSION < 2;
-		if (SUSTAINS_AS_ONE_NOTE == null) SUSTAINS_AS_ONE_NOTE = MOD_API_VERSION >= 2;
+		if (SUSTAINS_AS_ONE_NOTE == null) SUSTAINS_AS_ONE_NOTE = MOD_API_VERSION < 2;
 	}
 
 	public static function loadFromDatas(datas:Array<String>):Map<String, String> {


### PR DESCRIPTION
**Shouldn't `SUSTAINS_AS_ONE_NOTE` be enabled when `MOD_API_VERSION = 1`?**
**According to my understanding, `MOD_API_VERSION = 2` should be considered the legacy API.**