### PR TITLE
Improved text handling and keyboard input functionality for UITextBox

### DIFF
--- a/source/funkin/editors/ui/UITextBox.hx
+++ b/source/funkin/editors/ui/UITextBox.hx
@@ -201,7 +201,7 @@ class UITextBox extends UISliceSprite implements IUIFocusable {
 			case END:
 				position = label.text.length;
 			case V:
-				FlxG.sound.play(Paths.sound(Flags.DEFAULT_EDITOR_TEXTTYPE_SOUND));
+				FlxG.sound.play(Paths.sound(Flags.DEFAULT_EDITOR_PASTE_SOUND));
 				// Hey lj here, fixed copying because before we checked if the modifier was left or right ctrl
 				// but somehow it gave a int outside of the KeyModifier's range :sob:
 				// apparently there is a boolean that just checks for you. yw :D
@@ -214,7 +214,7 @@ class UITextBox extends UISliceSprite implements IUIFocusable {
 				if (data != null)
 					onTextInput(data);
 			case C:
-				FlxG.sound.play(Paths.sound(Flags.DEFAULT_EDITOR_TEXTTYPE_SOUND));
+				FlxG.sound.play(Paths.sound(Flags.DEFAULT_EDITOR_COPY_SOUND));
 				// if we are not holding ctrl, ignore
 				if (!modifier.ctrlKey)
 					return;
@@ -222,7 +222,7 @@ class UITextBox extends UISliceSprite implements IUIFocusable {
 				// copying
 				Clipboard.generalClipboard.setData(TEXT_FORMAT, label.text);
 			case X:
-				FlxG.sound.play(Paths.sound(Flags.DEFAULT_EDITOR_TEXTTYPE_SOUND));
+				FlxG.sound.play(Paths.sound(Flags.DEFAULT_EDITOR_CUT_SOUND));
 
 				// if we are not holding ctrl, ignore
 				if (!modifier.ctrlKey)


### PR DESCRIPTION
My one main gripe with the editors was the text boxes, they were a bit of a hassle to use, so I decided to implement a few things I thought would improve the usability of them quite a bit.

- Clamp position between 0 and text length (no more wrapping around)
- Disable sounds on modifier keys (control, alt, shift)
- Delete/Backspace for whole words (control + delete/backspace)
- Cut (control + x)
- Use cut paste copy sounds