### PR TITLE
Add Text displaying if the user is running an Experimental Version of CodenameEngine

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -35,7 +35,7 @@ jobs:
           haxe -cp commandline -D analyzer-optimize --run Main setup -s
       - name: Building the game
         run: |
-          haxelib run lime build linux
+          haxelib run lime build linux -DCOMPILE_EXPERIMENTAL
       # - name: Tar files
       #   run: tar -zcvf CodenameEngine.tar.gz -C export/release/linux/bin .
       - name: Uploading artifact (executable)

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -32,7 +32,7 @@ jobs:
           haxe -cp commandline -D analyzer-optimize --run Main setup -s
       - name: Building the game
         run: |
-          arch -x86_64 haxelib run lime build mac
+          arch -x86_64 haxelib run lime build mac -DCOMPILE_EXPERIMENTAL
       - name: Tar files
         run: tar -zcvf CodenameEngine.tar.gz -C export/release/macos/bin .
       - name: Uploading artifact (executable)

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -32,7 +32,7 @@ jobs:
           haxe -cp commandline -D analyzer-optimize --run Main setup -s --no-vscheck
       - name: Building the game
         run: |
-          haxelib run lime build windows
+          haxelib run lime build windows -DCOMPILE_EXPERIMENTAL
       - name: Uploading artifact (executable)
         uses: actions/upload-artifact@v4
         with:

--- a/source/funkin/backend/system/framerate/CodenameBuildField.hx
+++ b/source/funkin/backend/system/framerate/CodenameBuildField.hx
@@ -13,10 +13,14 @@ class CodenameBuildField extends TextField {
 	}
 
 	public function reload() {
+		#if COMPILE_EXPERIMENTAL
+		text = '${Flags.VERSION_MESSAGE} (Experimental Build)';
+		#else
 		text = '${Flags.VERSION_MESSAGE}';
-		#if debug
+		#end
+
+		#if (debug || COMPILE_EXPERIMENTAL)
 		text += '\n${Flags.COMMIT_MESSAGE}';
 		#end
-		// This is where I will add the feature but gonna test Github Actions first
 	}
 }

--- a/source/funkin/backend/system/framerate/CodenameBuildField.hx
+++ b/source/funkin/backend/system/framerate/CodenameBuildField.hx
@@ -17,5 +17,6 @@ class CodenameBuildField extends TextField {
 		#if debug
 		text += '\n${Flags.COMMIT_MESSAGE}';
 		#end
+		// This is where I will add the feature but gonna test Github Actions first
 	}
 }


### PR DESCRIPTION
This will not effect releases as it uses a different workflow with different commands, so this will help users who need help or reminder of what Experimental Build they are using to help looking at the source code comparisons.

<img width="1280" height="720" alt="Image showcasing the new '(Experimental Build)' text when running an experimental build." src="https://github.com/user-attachments/assets/974fbac4-729d-4e7e-86cb-9976ed2d949b" />
