### PR TITLE
Fix game crash when creating a difficulty

### DIFF
--- a/source/funkin/editors/charter/CharterSelection.hx
+++ b/source/funkin/editors/charter/CharterSelection.hx
@@ -146,11 +146,10 @@ class CharterSelectionScreen extends EditorTreeMenuScreen {
 
 		var screen = parent.tree.last();
 		var idx = 0;
-		while (!(screen.members[idx] is Separator)) idx++;
+		while (!(screen.members[idx] is Separator || idx >= screen.members.length)) idx++;
 		screen.insert(idx, makeChartOption(name, curSong.variant != null && curSong.variant != "" ? curSong.variant : null, curSong.name));
-
 		// Add to Meta
-		var metaPath = '$songFolder/meta${curSong.variant != null && curSong.variant == "" ? "-" + curSong.variant : ""}.json';
+		var metaPath = '$songFolder/meta${curSong.variant != null && curSong.variant != "" ? "-" + curSong.variant : ""}.json';
 		CoolUtil.safeSaveFile(metaPath, Chart.makeMetaSaveable(curSong));
 	}
 	#end


### PR DESCRIPTION
Fixes the freeze that would happen when there was no `Separator` in the difficulty list, which would make a `while` loop go on forever and freeze the game.
Also fixes an (I think) incorrect `==` to a `!=` when a new difficulty is made (which didnt even use to run due to the unbounded `while` loop, that's why it wasn't an issue).