### PR TITLE
Use default branch instead of use a specific version to avoid Node.js deprecations in the workflows

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           haxe-version: 4.3.7
       # - name: Restore existing build cache for faster compilation
-      #   uses: actions/cache@v4.2.3
+      #   uses: actions/cache@v5
       #   with:
       #     # not caching the bin folder to prevent asset duplication and stuff like that
       #     key: cache-build-linux
@@ -51,7 +51,7 @@ jobs:
           name: Codename Engine
           path: export/release/linux/bin/
       # - name: Clearing already existing cache
-      #   uses: actions/github-script@v6
+      #   uses: actions/github-script@v9
       #   with:
       #     script: |
       #       const caches = await github.rest.actions.getActionsCacheList({
@@ -70,7 +70,7 @@ jobs:
       #         }
       #       }
       # - name: Uploading new cache
-      #   uses: actions/cache@v4.2.3
+      #   uses: actions/cache@v5
       #   with:
       #     # caching again since for some reason it doesnt work with the first post cache shit
       #     key: cache-build-linux
@@ -92,7 +92,7 @@ jobs:
         with:
           haxe-version: 4.3.7
       # - name: Restore existing build cache for faster compilation
-      #   uses: actions/cache@v4.2.3
+      #   uses: actions/cache@v5
       #   with:
       #     # not caching the bin folder to prevent asset duplication and stuff like that
       #     key: cache-build-linux-debug
@@ -119,7 +119,7 @@ jobs:
           name: Codename Engine Debug
           path: export/debug/linux/bin/
       # - name: Clearing already existing cache
-      #   uses: actions/github-script@v6
+      #   uses: actions/github-script@v9
       #   with:
       #     script: |
       #       const caches = await github.rest.actions.getActionsCacheList({
@@ -138,7 +138,7 @@ jobs:
       #         }
       #       }
       # - name: Uploading new cache
-      #   uses: actions/cache@v4.2.3
+      #   uses: actions/cache@v5
       #   with:
       #     # caching again since for some reason it doesnt work with the first post cache shit
       #     key: cache-build-linux-debug

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -11,15 +11,15 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Pulling the new commit
-        uses: actions/checkout@v6
+        uses: actions/checkout@main
         with:
           fetch-depth: 0
       - name: Setting up Haxe
-        uses: krdlab/setup-haxe@v2
+        uses: krdlab/setup-haxe@master
         with:
           haxe-version: 4.3.7
       # - name: Restore existing build cache for faster compilation
-      #   uses: actions/cache@v5
+      #   uses: actions/cache@main
       #   with:
       #     # not caching the bin folder to prevent asset duplication and stuff like that
       #     key: cache-build-linux
@@ -41,17 +41,17 @@ jobs:
       # - name: Tar files
       #   run: tar -zcvf CodenameEngine.tar.gz -C export/release/linux/bin .
       - name: Uploading artifact (executable)
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@main
         with:
           name: Codename Engine (Executable Only)
           path: export/release/linux/bin/CodenameEngine
       - name: Uploading artifact (entire build)
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@main
         with:
           name: Codename Engine
           path: export/release/linux/bin/
       # - name: Clearing already existing cache
-      #   uses: actions/github-script@v9
+      #   uses: actions/github-script@main
       #   with:
       #     script: |
       #       const caches = await github.rest.actions.getActionsCacheList({
@@ -70,7 +70,7 @@ jobs:
       #         }
       #       }
       # - name: Uploading new cache
-      #   uses: actions/cache@v5
+      #   uses: actions/cache@main
       #   with:
       #     # caching again since for some reason it doesnt work with the first post cache shit
       #     key: cache-build-linux
@@ -86,13 +86,13 @@ jobs:
     needs: build # since its low priority, it'll run after, so actions will concentrate first on normal builds
     steps:
       - name: Pulling the new commit
-        uses: actions/checkout@v6
+        uses: actions/checkout@main
       - name: Setting up Haxe
-        uses: krdlab/setup-haxe@v2
+        uses: krdlab/setup-haxe@master
         with:
           haxe-version: 4.3.7
       # - name: Restore existing build cache for faster compilation
-      #   uses: actions/cache@v5
+      #   uses: actions/cache@main
       #   with:
       #     # not caching the bin folder to prevent asset duplication and stuff like that
       #     key: cache-build-linux-debug
@@ -114,12 +114,12 @@ jobs:
       # - name: Tar files
       #   run: tar -zcvf CodenameEngine.tar.gz -C export/debug/linux/bin .
       - name: Uploading artifact (entire build)
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@main
         with:
           name: Codename Engine Debug
           path: export/debug/linux/bin/
       # - name: Clearing already existing cache
-      #   uses: actions/github-script@v9
+      #   uses: actions/github-script@main
       #   with:
       #     script: |
       #       const caches = await github.rest.actions.getActionsCacheList({
@@ -138,7 +138,7 @@ jobs:
       #         }
       #       }
       # - name: Uploading new cache
-      #   uses: actions/cache@v5
+      #   uses: actions/cache@main
       #   with:
       #     # caching again since for some reason it doesnt work with the first post cache shit
       #     key: cache-build-linux-debug

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -11,15 +11,15 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Pulling the new commit
-        uses: actions/checkout@v6
+        uses: actions/checkout@main
         with:
           fetch-depth: 0
       - name: Setting up Haxe
-        uses: krdlab/setup-haxe@v2
+        uses: krdlab/setup-haxe@master
         with:
           haxe-version: 4.3.7
       # - name: Restore existing build cache for faster compilation
-      #   uses: actions/cache@v5
+      #   uses: actions/cache@main
       #   with:
       #     # not caching the bin folder to prevent asset duplication and stuff like that
       #     key: cache-build-mac
@@ -38,17 +38,17 @@ jobs:
       - name: Tar files
         run: tar -zcvf CodenameEngine.tar.gz -C export/release/macos/bin .
       - name: Uploading artifact (executable)
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@main
         with:
           name: Codename Engine (Executable Only)
           path: export/release/macos/bin/CodenameEngine.app/Contents/MacOS/CodenameEngine
       - name: Uploading artifact (entire build)
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@main
         with:
           name: Codename Engine
           path: CodenameEngine.tar.gz
       # - name: Clearing already existing cache
-      #   uses: actions/github-script@v9
+      #   uses: actions/github-script@main
       #   with:
       #     script: |
       #       const caches = await github.rest.actions.getActionsCacheList({
@@ -67,7 +67,7 @@ jobs:
       #         }
       #       }
       # - name: Uploading new cache
-      #   uses: actions/cache@v5
+      #   uses: actions/cache@main
       #   with:
       #     # caching again since for some reason it doesnt work with the first post cache shit
       #     key: cache-build-mac
@@ -83,13 +83,13 @@ jobs:
     needs: build # since its low priority, it'll run after, so actions will concentrate first on normal builds
     steps:
       - name: Pulling the new commit
-        uses: actions/checkout@v6
+        uses: actions/checkout@main
       - name: Setting up Haxe
-        uses: krdlab/setup-haxe@v2
+        uses: krdlab/setup-haxe@master
         with:
           haxe-version: 4.3.7
       # - name: Restore existing build cache for faster compilation
-      #   uses: actions/cache@v5
+      #   uses: actions/cache@main
       #   with:
       #     # not caching the bin folder to prevent asset duplication and stuff like that
       #     key: cache-build-mac-debug
@@ -108,12 +108,12 @@ jobs:
       - name: Tar files
         run: tar -zcvf CodenameEngine.tar.gz -C export/debug/macos/bin .
       - name: Uploading artifact (entire build)
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@main
         with:
           name: Codename Engine Debug
           path: CodenameEngine.tar.gz
       # - name: Clearing already existing cache
-      #   uses: actions/github-script@v9
+      #   uses: actions/github-script@main
       #   with:
       #     script: |
       #       const caches = await github.rest.actions.getActionsCacheList({
@@ -132,7 +132,7 @@ jobs:
       #         }
       #       }
       # - name: Uploading new cache
-      #   uses: actions/cache@v5
+      #   uses: actions/cache@main
       #   with:
       #     # caching again since for some reason it doesnt work with the first post cache shit
       #     key: cache-build-mac-debug

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           haxe-version: 4.3.7
       # - name: Restore existing build cache for faster compilation
-      #   uses: actions/cache@v4.2.3
+      #   uses: actions/cache@v5
       #   with:
       #     # not caching the bin folder to prevent asset duplication and stuff like that
       #     key: cache-build-mac
@@ -48,7 +48,7 @@ jobs:
           name: Codename Engine
           path: CodenameEngine.tar.gz
       # - name: Clearing already existing cache
-      #   uses: actions/github-script@v6
+      #   uses: actions/github-script@v9
       #   with:
       #     script: |
       #       const caches = await github.rest.actions.getActionsCacheList({
@@ -67,7 +67,7 @@ jobs:
       #         }
       #       }
       # - name: Uploading new cache
-      #   uses: actions/cache@v4.2.3
+      #   uses: actions/cache@v5
       #   with:
       #     # caching again since for some reason it doesnt work with the first post cache shit
       #     key: cache-build-mac
@@ -89,7 +89,7 @@ jobs:
         with:
           haxe-version: 4.3.7
       # - name: Restore existing build cache for faster compilation
-      #   uses: actions/cache@v4.2.3
+      #   uses: actions/cache@v5
       #   with:
       #     # not caching the bin folder to prevent asset duplication and stuff like that
       #     key: cache-build-mac-debug
@@ -113,7 +113,7 @@ jobs:
           name: Codename Engine Debug
           path: CodenameEngine.tar.gz
       # - name: Clearing already existing cache
-      #   uses: actions/github-script@v6
+      #   uses: actions/github-script@v9
       #   with:
       #     script: |
       #       const caches = await github.rest.actions.getActionsCacheList({
@@ -132,7 +132,7 @@ jobs:
       #         }
       #       }
       # - name: Uploading new cache
-      #   uses: actions/cache@v4.2.3
+      #   uses: actions/cache@v5
       #   with:
       #     # caching again since for some reason it doesnt work with the first post cache shit
       #     key: cache-build-mac-debug

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,7 +178,7 @@ jobs:
           echo -e "Final pre-changelog message:\n\n$BODY"
 
       - name: Create GitHub Release with Assets
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download Windows Full Build
-        uses: dawidd6/action-download-artifact@v8
+        uses: dawidd6/action-download-artifact@v17
         with:
           workflow: windows.yml
           name: Codename Engine
@@ -34,7 +34,7 @@ jobs:
           allow_forks: false
 
       - name: Download Windows Executable
-        uses: dawidd6/action-download-artifact@v8
+        uses: dawidd6/action-download-artifact@v17
         with:
           workflow: windows.yml
           name: Codename Engine (Executable Only)
@@ -42,7 +42,7 @@ jobs:
           allow_forks: false
 
       - name: Download Mac OS Full Build
-        uses: dawidd6/action-download-artifact@v8
+        uses: dawidd6/action-download-artifact@v17
         with:
           workflow: macos.yml
           name: Codename Engine
@@ -50,7 +50,7 @@ jobs:
           allow_forks: false
 
       - name: Download Mac OS Executable
-        uses: dawidd6/action-download-artifact@v8
+        uses: dawidd6/action-download-artifact@v17
         with:
           workflow: macos.yml
           name: Codename Engine (Executable Only)
@@ -58,7 +58,7 @@ jobs:
           allow_forks: false
 
       - name: Download Linux Full Build
-        uses: dawidd6/action-download-artifact@v8
+        uses: dawidd6/action-download-artifact@v17
         with:
           workflow: linux.yml
           name: Codename Engine
@@ -66,7 +66,7 @@ jobs:
           allow_forks: false
 
       - name: Download Linux Executable
-        uses: dawidd6/action-download-artifact@v8
+        uses: dawidd6/action-download-artifact@v17
         with:
           workflow: linux.yml
           name: Codename Engine (Executable Only)
@@ -178,7 +178,7 @@ jobs:
           echo -e "Final pre-changelog message:\n\n$BODY"
 
       - name: Create GitHub Release with Assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,12 +21,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@main
         with:
           fetch-depth: 0
 
       - name: Download Windows Full Build
-        uses: dawidd6/action-download-artifact@v17
+        uses: dawidd6/action-download-artifact@main
         with:
           workflow: windows.yml
           name: Codename Engine
@@ -34,7 +34,7 @@ jobs:
           allow_forks: false
 
       - name: Download Windows Executable
-        uses: dawidd6/action-download-artifact@v17
+        uses: dawidd6/action-download-artifact@main
         with:
           workflow: windows.yml
           name: Codename Engine (Executable Only)
@@ -42,7 +42,7 @@ jobs:
           allow_forks: false
 
       - name: Download Mac OS Full Build
-        uses: dawidd6/action-download-artifact@v17
+        uses: dawidd6/action-download-artifact@main
         with:
           workflow: macos.yml
           name: Codename Engine
@@ -50,7 +50,7 @@ jobs:
           allow_forks: false
 
       - name: Download Mac OS Executable
-        uses: dawidd6/action-download-artifact@v17
+        uses: dawidd6/action-download-artifact@main
         with:
           workflow: macos.yml
           name: Codename Engine (Executable Only)
@@ -58,7 +58,7 @@ jobs:
           allow_forks: false
 
       - name: Download Linux Full Build
-        uses: dawidd6/action-download-artifact@v17
+        uses: dawidd6/action-download-artifact@main
         with:
           workflow: linux.yml
           name: Codename Engine
@@ -66,7 +66,7 @@ jobs:
           allow_forks: false
 
       - name: Download Linux Executable
-        uses: dawidd6/action-download-artifact@v17
+        uses: dawidd6/action-download-artifact@main
         with:
           workflow: linux.yml
           name: Codename Engine (Executable Only)
@@ -178,7 +178,7 @@ jobs:
           echo -e "Final pre-changelog message:\n\n$BODY"
 
       - name: Create GitHub Release with Assets
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,15 +11,15 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Pulling the new commit
-        uses: actions/checkout@v6
+        uses: actions/checkout@main
         with:
           fetch-depth: 0
       - name: Setting up Haxe
-        uses: krdlab/setup-haxe@v2
+        uses: krdlab/setup-haxe@master
         with:
           haxe-version: 4.3.7
       # - name: Restore existing build cache for faster compilation
-      #   uses: actions/cache@v5
+      #   uses: actions/cache@main
       #   with:
       #     # not caching the bin folder to prevent asset duplication and stuff like that
       #     key: cache-build-windows
@@ -36,19 +36,19 @@ jobs:
           haxelib run lime rebuild windows -nocolor -nocffi -release
           haxelib run lime build windows -DCOMPILE_EXPERIMENTAL
       - name: Uploading artifact (executable)
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@main
         with:
           name: Codename Engine (Executable Only)
           path: |
             export/release/windows/bin/CodenameEngine.exe
             export/release/windows/bin/lime.ndll
       - name: Uploading artifact (entire build)
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@main
         with:
           name: Codename Engine
           path: export/release/windows/bin
       # - name: Clearing already existing cache
-      #   uses: actions/github-script@v9
+      #   uses: actions/github-script@main
       #   with:
       #     script: |
       #       const caches = await github.rest.actions.getActionsCacheList({
@@ -67,7 +67,7 @@ jobs:
       #         }
       #       }
       # - name: Uploading new cache
-      #   uses: actions/cache@v5
+      #   uses: actions/cache@main
       #   with:
       #     # caching again since for some reason it doesnt work with the first post cache shit
       #     key: cache-build-windows
@@ -83,13 +83,13 @@ jobs:
     needs: build # since its low priority, it'll run after, so actions will concentrate first on normal builds
     steps:
       - name: Pulling the new commit
-        uses: actions/checkout@v6
+        uses: actions/checkout@main
       - name: Setting up Haxe
-        uses: krdlab/setup-haxe@v2
+        uses: krdlab/setup-haxe@master
         with:
           haxe-version: 4.3.7
       # - name: Restore existing build cache for faster compilation
-      #   uses: actions/cache@v5
+      #   uses: actions/cache@main
       #   with:
       #     # not caching the bin folder to prevent asset duplication and stuff like that
       #     key: cache-build-windows-debug
@@ -107,12 +107,12 @@ jobs:
           haxelib run lime rebuild windows -nocolor -nocffi -debug
           haxelib run lime build windows -debug
       - name: Uploading artifact (entire build)
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@main
         with:
           name: Codename Engine Debug
           path: export/debug/windows/bin
       # - name: Clearing already existing cache
-      #   uses: actions/github-script@v9
+      #   uses: actions/github-script@main
       #   with:
       #     script: |
       #       const caches = await github.rest.actions.getActionsCacheList({
@@ -131,7 +131,7 @@ jobs:
       #         }
       #       }
       # - name: Uploading new cache
-      #   uses: actions/cache@v5
+      #   uses: actions/cache@main
       #   with:
       #     # caching again since for some reason it doesnt work with the first post cache shit
       #     key: cache-build-windows-debug

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -112,7 +112,7 @@ jobs:
           name: Codename Engine Debug
           path: export/debug/windows/bin
       # - name: Clearing already existing cache
-      #   uses: actions/github-script@v6
+      #   uses: actions/github-script@v9
       #   with:
       #     script: |
       #       const caches = await github.rest.actions.getActionsCacheList({

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           haxe-version: 4.3.7
       # - name: Restore existing build cache for faster compilation
-      #   uses: actions/cache@v4.2.3
+      #   uses: actions/cache@v5
       #   with:
       #     # not caching the bin folder to prevent asset duplication and stuff like that
       #     key: cache-build-windows
@@ -48,7 +48,7 @@ jobs:
           name: Codename Engine
           path: export/release/windows/bin
       # - name: Clearing already existing cache
-      #   uses: actions/github-script@v6
+      #   uses: actions/github-script@v9
       #   with:
       #     script: |
       #       const caches = await github.rest.actions.getActionsCacheList({
@@ -67,7 +67,7 @@ jobs:
       #         }
       #       }
       # - name: Uploading new cache
-      #   uses: actions/cache@v4.2.3
+      #   uses: actions/cache@v5
       #   with:
       #     # caching again since for some reason it doesnt work with the first post cache shit
       #     key: cache-build-windows
@@ -89,7 +89,7 @@ jobs:
         with:
           haxe-version: 4.3.7
       # - name: Restore existing build cache for faster compilation
-      #   uses: actions/cache@v4.2.3
+      #   uses: actions/cache@v5
       #   with:
       #     # not caching the bin folder to prevent asset duplication and stuff like that
       #     key: cache-build-windows-debug
@@ -131,7 +131,7 @@ jobs:
       #         }
       #       }
       # - name: Uploading new cache
-      #   uses: actions/cache@v4.2.3
+      #   uses: actions/cache@v5
       #   with:
       #     # caching again since for some reason it doesnt work with the first post cache shit
       #     key: cache-build-windows-debug


### PR DESCRIPTION
I forgot to update those, because I checked in the main branch and it does affect on both of them due to Node.js version deprecation. even though they were disabled for now in the internal merge branch.